### PR TITLE
Throw when association helper is used with polymorphic belongsTo

### DIFF
--- a/__tests__/external/shared/factories/helpers-test.js
+++ b/__tests__/external/shared/factories/helpers-test.js
@@ -136,4 +136,27 @@ describe("Eternal | Shared | Factories | helpers", () => {
       server.create("page");
     }).toThrow();
   });
+
+  test("it allows to use association helper with polymorphic relationship", () => {
+    server = new Server({
+      environment: "test",
+      models: {
+        author: Model.extend({
+          anyPost: belongsTo("base-post", { polymorphic: true })
+        }),
+        basePost: Model.extend({})
+      },
+      factories: {
+        author: Factory.extend({
+          anyPost: association()
+        }),
+        basePost: Factory.extend({
+          title: "base title"
+        })
+      }
+    });
+
+    let author = server.create("author");
+    expect(author.anyPost.title).toEqual("base title");
+  });
 });

--- a/__tests__/external/shared/factories/helpers-test.js
+++ b/__tests__/external/shared/factories/helpers-test.js
@@ -137,7 +137,7 @@ describe("Eternal | Shared | Factories | helpers", () => {
     }).toThrow();
   });
 
-  test("it allows to use association helper with polymorphic relationship", () => {
+  test("it throws if using the association helper with polymorphic relationship", () => {
     server = new Server({
       environment: "test",
       models: {
@@ -149,14 +149,12 @@ describe("Eternal | Shared | Factories | helpers", () => {
       factories: {
         author: Factory.extend({
           anyPost: association()
-        }),
-        basePost: Factory.extend({
-          title: "base title"
         })
       }
     });
 
-    let author = server.create("author");
-    expect(author.anyPost.title).toEqual("base title");
+    expect(() => {
+      server.create("author");
+    }).toThrow();
   });
 });

--- a/lib/server.js
+++ b/lib/server.js
@@ -1266,22 +1266,21 @@ export default class Server {
           `You're using the association() helper on your ${modelName} factory for ${attr}, which is a belongsTo self-referential relationship. You can't do this as it will lead to infinite recursion. You can move the helper inside of a trait and use it selectively.`
         );
 
+        let isPolymorphic =
+          association && association.opts && association.opts.polymorphic;
+
+        assert(
+          !isPolymorphic,
+          `You're using the association() helper on your ${modelName} factory for ${attr}, which is a polymorphic relationship. This is not currently supported.`
+        );
+
         let factoryAssociation = attributes[attr];
         let foreignKey = `${camelize(attr)}Id`;
         if (!overrides[attr]) {
-          let foreignId = this.create(
+          attributes[foreignKey] = this.create(
             association.modelName,
             ...factoryAssociation.traitsAndOverrides
           ).id;
-
-          if (association.opts.polymorphic) {
-            foreignId = {
-              type: association.modelName,
-              id: foreignId
-            };
-          }
-
-          attributes[foreignKey] = foreignId;
         }
         delete attributes[attr];
       });

--- a/lib/server.js
+++ b/lib/server.js
@@ -620,7 +620,7 @@ export default class Server {
       ...,
       seeds(server) {
         server.loadFixtures('countries', 'states');
-    
+
         let author = server.create('author');
         server.createList('post', 10, {author_id: author.id});
       }
@@ -1269,10 +1269,19 @@ export default class Server {
         let factoryAssociation = attributes[attr];
         let foreignKey = `${camelize(attr)}Id`;
         if (!overrides[attr]) {
-          attributes[foreignKey] = this.create(
+          let foreignId = this.create(
             association.modelName,
             ...factoryAssociation.traitsAndOverrides
           ).id;
+
+          if (association.opts.polymorphic) {
+            foreignId = {
+              type: association.modelName,
+              id: foreignId
+            };
+          }
+
+          attributes[foreignKey] = foreignId;
         }
         delete attributes[attr];
       });


### PR DESCRIPTION
I stumbled upon this while working on the app so decided why not fix it :-)

Basically foreign key validation for polymorphic expects `{ type, id }` object here:

https://github.com/miragejs/miragejs/blob/4ab442d1570625e8ccfdfed04f5c7c87d1269350/lib/orm/model.js#L712-L714