### PR TITLE
added MirageError when handling errors in route-handler

### DIFF
--- a/__tests__/internal/move-after-handle-request/route-handlers/function-handler/basic-test.js
+++ b/__tests__/internal/move-after-handle-request/route-handlers/function-handler/basic-test.js
@@ -32,7 +32,7 @@ describe("Integration | Route handlers | Function handler", () => {
     let res = await fetch("/users");
     let data = await res.json();
 
-    expect(data.message).toBe("I goofed");
+    expect(data.message).toBe("Mirage: I goofed");
     expect(data.stack).toMatch(
       "Mirage: Your GET handler for the url /users threw an error"
     );

--- a/lib/route-handler.js
+++ b/lib/route-handler.js
@@ -95,12 +95,12 @@ export default class RouteHandler {
         result = new Response(
           500,
           {},
-          {
+          new MirageError(
             message,
-            stack: `Mirage: Your ${request.method} handler for the url ${
+            `Mirage: Your ${request.method} handler for the url ${
               request.url
             } threw an error:\n\n${e.stack || e}`
-          }
+          )
         );
       }
     }


### PR DESCRIPTION
Solved #185 
I added a MirageError when catching an error on the routerHandler. So the user will have more information about the error.
Is it that you where thinking when you reported the issue?