### PR TITLE
Fix GitHub issue link in API docs

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -267,7 +267,7 @@ export default class Server {
 
       If your app is loaded from the filesystem vs. a server (e.g. via Cordova or Electron vs. `localhost` or `https://yourhost.com/`), you will need to explicitly define a namespace. Likely values are `/` (if requests are made with relative paths) or `https://yourhost.com/api/...` (if requests are made to a defined server).
 
-      For a sample implementation leveraging a configured API host & namespace, check out [this issue comment](https://github.com/samselikoff/ember-cli-jkissues/497#issuecomment-183458721).
+      For a sample implementation leveraging a configured API host & namespace, check out [this issue comment](https://github.com/miragejs/ember-cli-mirage/issues/497#issuecomment-183458721).
 
       @property namespace
       @type String


### PR DESCRIPTION
This fixes the GitHub issue links in the API docs for `namespace` in the "Server" class where the link was getting the GitHub 404 error page.