### PR TITLE
docs: Add server options types

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -182,6 +182,27 @@ function extractRouteArguments(args) {
   @public
 */
 export default class Server {
+  /**
+   * Creates a Server
+   * @param {Object} options Server's configuration object
+   * @param {String} options.urlPrefix The base URL for the routes. Example: `http://miragejs.com`.
+   * @param {String} options.namespace The default namespace for the `Server`. Example: `/api/v1`.
+   * @param {Number} options.timing Default latency for the routes to respond to a request.
+   * @param {String} options.environment Defines the environment of the `Server`.
+   * @param {Boolean} options.trackRequests Pretender `trackRequests`.
+   * @param {Boolean} options.useDefaultPassthroughs True to use mirage provided passthroughs
+   * @param {Boolean} options.logging Set to true or false to explicitly specify logging behavior.
+   * @param {Function} options.seeds Called on the seed phase. Should be used to seed the database.
+   * @param {Function} options.scenarios Alias for seeds.
+   * @param {Function} options.routes Should be used to define server routes.
+   * @param {Function} options.baseConfig Alias for routes.
+   * @param {Object} options.inflector Default inflector (used for pluralization and singularization).
+   * @param {Object} options.identityManagers Database identity managers.
+   * @param {Object} options.models Server models
+   * @param {Object} options.serializers Server serializers
+   * @param {Object} options.factories Server factories
+   * @param {Object} options.pretender Pretender instance
+   */
   constructor(options = {}) {
     this._container = new Container();
     this.config(options);


### PR DESCRIPTION
- Adds esdoc types for `Server` constructor arguments

Related https://github.com/miragejs/site/pull/199

If both are merged, docs will be as shown on the link ☝️ 