### PR TITLE
Fix passthrough function with queryParams

### DIFF
--- a/__tests__/external/browser-only/passthrough-test.js
+++ b/__tests__/external/browser-only/passthrough-test.js
@@ -157,12 +157,14 @@ describe("External | Browser only | Passthrough", () => {
     server.config({
       routes() {
         this.passthrough(request => {
-          return request.url === "/users";
+          return request.url.match(/users/);
         });
       }
     });
 
-    await expect(fetch("/users")).rejects.toThrow("Network request failed");
+    await expect(fetch("/users?test=withQueryParams")).rejects.toThrow(
+      "Network request failed"
+    );
 
     await expect(fetch("/movies")).rejects.toThrow(
       `Mirage: Your app tried to GET '/movies'`

--- a/lib/server.js
+++ b/lib/server.js
@@ -82,7 +82,11 @@ function createPretender(server) {
           );
 
           if (shouldPassthrough) {
-            this[request.method.toLowerCase()](request.url, this.passthrough);
+            let url = request.url.includes("?")
+              ? request.url.substr(0, request.url.indexOf("?"))
+              : request.url;
+
+            this[request.method.toLowerCase()](url, this.passthrough);
           }
 
           return originalCheckPassthrough.apply(this, arguments);


### PR DESCRIPTION
# Bug

Currently, passing a function to the `passthrough` method will break if the "request to be passthrough" has queryParams.

This PR fixes it