### PR TITLE
Add missing fixtures property to ServerConfig type definition

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -228,6 +228,7 @@ declare module "miragejs/server" {
 
   export interface ServerConfig {
     urlPrefix?: string;
+    fixtures?: any;
     namespace?: string;
     timing?: number;
     environment?: string;

--- a/types/tests/server-test.ts
+++ b/types/tests/server-test.ts
@@ -38,6 +38,13 @@ export default function config(this: Server): void {
 }
 
 const server = new Server({
+  fixtures: {
+    countries: [
+      { id: 1, name: "China" },
+      { id: 2, name: "India" },
+      { id: 3, name: "United States" },
+    ],
+  },
   routes() {
     this.namespace = "api";
 


### PR DESCRIPTION
fix #392

- Add `fixtures` property to `ServerConfig` interface. At the moment it is a vague `any`, we can be more specific later and force strict type configuration.