### PR TITLE
Simplify typed usage of relationships

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -10,10 +10,11 @@ declare module "miragejs" {
   import {
     FactoryDefinition,
     ModelDefinition,
-    ModelInstance,
+    BelongsTo,
+    HasMany,
   } from "miragejs/-types";
   export { Server } from "miragejs/server";
-  export { Registry, ModelInstance } from "miragejs/-types";
+  export { Registry, Instantiate, ModelInstance } from "miragejs/-types";
 
   /**
    * A fake HTTP request
@@ -91,38 +92,38 @@ declare module "miragejs" {
     polymorphic?: boolean;
   }
 
-  /** The registry-aware type of Mirage's `belongsTo` function */
-  // prettier-ignore
-  export type BelongsTo<Registry> =
-      & (<K extends keyof Registry>(key?: K, options?: RelationshipOptions) => () => Registry[K] | undefined)
-      & (<K extends keyof Registry>(options: RelationshipOptions & { polymorphic: true }) => () => Registry[K] | undefined);
-
   /** Declares a one-to-one relationship to another Mirage model type. */
-  export function belongsTo<T extends ModelInstance = ModelInstance>(
-    key?: string,
+  export function belongsTo<K extends string>(
+    key?: K,
     options?: RelationshipOptions
-  ): () => T | undefined;
-  export function belongsTo<T extends ModelInstance = ModelInstance>(
+  ): BelongsTo<K>;
+  export function belongsTo<K extends string>(
     options?: RelationshipOptions
-  ): () => T | undefined;
-
-  /** The registry-aware type of Mirage's `hasMany` function */
-  // prettier-ignore
-  export type HasMany<Registry> =
-      & (<K extends keyof Registry>(key?: K, options?: RelationshipOptions) => () => Collection<Registry[K]>)
-      & (<K extends keyof Registry>(options: RelationshipOptions & { polymorphic: true }) => () => Collection<Registry[K]>);
+  ): BelongsTo<K>;
 
   /** Declares a one-to-many relationship to another Mirage model type. */
-  export function hasMany<T extends ModelInstance = ModelInstance>(
-    key?: string,
+  export function hasMany<K extends string>(
+    key?: K,
     options?: RelationshipOptions
-  ): () => Collection<T>;
-  export function hasMany<T extends ModelInstance = ModelInstance>(
+  ): HasMany<K>;
+  export function hasMany<K extends string>(
     options?: RelationshipOptions
-  ): () => Collection<T>;
+  ): HasMany<K>;
 }
 
 declare module "miragejs/-types" {
+  import { Collection } from "miragejs";
+
+  /* A 1:1 relationship between models */
+  export class BelongsTo<Name extends string> {
+    private name: Name;
+  }
+
+  /* A 1:many relationship between models */
+  export class HasMany<Name extends string> {
+    private name: Name;
+  }
+
   // Captures the result of a `Model.extend()` call
   interface ModelDefinition<Data extends {} = {}> {
     extend<NewData>(data: NewData): ModelDefinition<Assign<Data, NewData>>;
@@ -133,23 +134,58 @@ declare module "miragejs/-types" {
     extend<NewData>(data: NewData): FactoryDefinition<Assign<Data, NewData>>;
   }
 
-  // The type-level equivalent of `Object.assign`
-  type Assign<T, U> = U & Omit<T, keyof U>;
-
-  // Extract relationship values from a model definition
-  type FlattenRelationships<T> = {
-    [K in keyof T]: T[K] extends () => infer Value ? Value : T[K];
-  };
-
   // Extract factory method return values from a factory definition
   type FlattenFactoryMethods<T> = {
     [K in keyof T]: T[K] extends (n: number) => infer V ? V : T[K];
   };
 
+  /**
+   * Given a registry and the name of one of the models defined in it,
+   * returns the type of that model as instantiated by Mirage.
+   */
+  export type Instantiate<
+    Registry,
+    ModelName extends keyof Registry
+  > = ModelInstance<
+    {
+      // Splitting and rejoining on `ModelName` ensures that unions distribute
+      // properly, so that `Instantiate<Reg, 'foo' | 'bar'>` expands out like
+      // `Instantiate<Reg, 'foo'> | Instantiate<Reg, 'bar'>` rather than something
+      // that only has the intersection of `foo` and `bar`'s keys.
+      [Model in ModelName]: {
+        [Key in keyof Registry[Model]]: InstantiateValue<
+          Registry,
+          Registry[Model][Key]
+        >;
+      };
+    }[ModelName]
+  >;
+
+  // Given a registry and value type, checks whether that type represents
+  // if Mirage relationship. If so, returns the corresponding model or
+  // collection type from the registry; otherwise returns the type unchanged.
+  type InstantiateValue<Registry, T> = T extends BelongsTo<infer ModelName>
+    ? InstantiateIfDefined<Registry, ModelName> | null
+    : T extends HasMany<infer ModelName>
+    ? Collection<InstantiateIfDefined<Registry, ModelName>>
+    : T;
+
+  // Returns the instantiated type of the given model if it exists in the
+  // given registry, or `unknown` otherwise.
+  type InstantiateIfDefined<
+    Registry,
+    ModelName
+  > = ModelName extends keyof Registry
+    ? Instantiate<Registry, ModelName>
+    : unknown;
+
+  // The type-level equivalent of `Object.assign`
+  type Assign<T, U> = U & Omit<T, keyof U>;
+
   // Extracts model definition info for the given key, if a corresponding model is defined
   type ExtractModelData<Models, K> = K extends keyof Models
     ? Models[K] extends ModelDefinition<infer Data>
-      ? FlattenRelationships<Data>
+      ? Data
       : {}
     : {};
 
@@ -169,9 +205,8 @@ declare module "miragejs/-types" {
     Models extends AnyModels,
     Factories extends AnyFactories
   > = {
-    [K in keyof Models | keyof Factories]: ModelInstance<
-      ExtractModelData<Models, K> & ExtractFactoryData<Factories, K>
-    >;
+    [K in keyof Models | keyof Factories]: ExtractModelData<Models, K> &
+      ExtractFactoryData<Factories, K>;
   };
 
   export type AnyModels = Record<string, ModelDefinition>;
@@ -203,7 +238,12 @@ declare module "miragejs/-types" {
 
 declare module "miragejs/server" {
   import { Request, Response, Registry as MirageRegistry } from "miragejs";
-  import { AnyRegistry, AnyModels, AnyFactories } from "miragejs/-types";
+  import {
+    AnyRegistry,
+    AnyModels,
+    AnyFactories,
+    Instantiate,
+  } from "miragejs/-types";
   import { ModelInstance } from "miragejs/-types";
   import Db from "miragejs/db";
   import IdentityManager from "miragejs/identity-manager";
@@ -279,7 +319,7 @@ declare module "miragejs/server" {
     /** Creates multiple models of the given type. */
     createList<
       K extends keyof Registry,
-      Init extends Registry[K],
+      Init extends Instantiate<Registry, K>,
       Data extends Partial<Init>
     >(modelName: K, count: number, data?: Data): Array<Init & Data>;
 
@@ -426,7 +466,7 @@ declare module "miragejs/identity-manager" {
 
 declare module "miragejs/orm/schema" {
   import { Collection } from "miragejs";
-  import { AnyRegistry } from "miragejs/-types";
+  import { AnyRegistry, Instantiate } from "miragejs/-types";
   import Db from "miragejs/db";
 
   type ModelInitializer<Data> = {
@@ -449,45 +489,55 @@ declare module "miragejs/orm/schema" {
      */
     create<
       K extends keyof Registry,
-      Init extends Registry[K],
+      Init extends Instantiate<Registry, K>,
       Data extends Partial<ModelInitializer<Init>>
     >(
       modelName: K,
       data?: Data
-    ): Init & { [K in keyof Init & keyof Data]: Exclude<Init[K], undefined> };
+    ): Init &
+      { [K in keyof Init & keyof Data]: Exclude<Init[K], undefined | null> };
 
     /** Locates one or more existing models of the given type by ID(s). */
-    find<K extends keyof Registry>(type: K, id: string): Registry[K] | null;
+    find<K extends keyof Registry>(
+      type: K,
+      id: string
+    ): Instantiate<Registry, K> | null;
     find<K extends keyof Registry>(
       type: K,
       ids: string[]
-    ): Collection<Registry[K]>;
+    ): Collection<Instantiate<Registry, K>>;
 
     /** Locates an existing model of the given type by attribute value(s), if one exists. */
     findBy<K extends keyof Registry>(
       type: K,
-      attributes: Partial<Registry[K]>
-    ): Registry[K] | null;
+      attributes: Partial<Instantiate<Registry, K>>
+    ): Instantiate<Registry, K> | null;
 
     /** Locates an existing model of the given type by attribute value(s), creating one if it doesn't exist. */
     findOrCreateBy<K extends keyof Registry>(
       type: K,
-      attributes: Partial<Registry[K]>
-    ): Registry[K];
+      attributes: Partial<Instantiate<Registry, K>>
+    ): Instantiate<Registry, K>;
 
     /** Locates an existing model of the given type by attribute value(s), if one exists. */
     where<K extends keyof Registry>(
       type: K,
-      attributes: Partial<Registry[K]> | ((item: Registry[K]) => unknown)
-    ): Collection<Registry[K]>;
+      attributes:
+        | Partial<Instantiate<Registry, K>>
+        | ((item: Instantiate<Registry, K>) => unknown)
+    ): Collection<Instantiate<Registry, K>>;
 
     /** Returns a collection of all known records of the given type */
-    all<K extends keyof Registry>(type: K): Collection<Registry[K]>;
+    all<K extends keyof Registry>(
+      type: K
+    ): Collection<Instantiate<Registry, K>>;
 
     /** Returns an empty collection of the given type */
-    none<K extends keyof Registry>(type: K): Collection<Registry[K]>;
+    none<K extends keyof Registry>(
+      type: K
+    ): Collection<Instantiate<Registry, K>>;
 
     /** Returns the first model instance found of the given type */
-    first<K extends keyof Registry>(type: K): Registry[K] | null;
+    first<K extends keyof Registry>(type: K): Instantiate<Registry, K> | null;
   }
 }

--- a/types/tests/relationships-test.ts
+++ b/types/tests/relationships-test.ts
@@ -1,26 +1,19 @@
-import {
-  belongsTo,
-  BelongsTo,
-  hasMany,
-  HasMany,
-  Model,
-  Registry,
-} from "miragejs";
+import { belongsTo, hasMany, Model, Registry } from "miragejs";
 import Schema from "miragejs/orm/schema";
-
-const registryBelongsTo: BelongsTo<PersonRegistry> = belongsTo;
-const registryHasMany: HasMany<PersonRegistry> = hasMany;
 
 const PersonModel = Model.extend({
   name: "hello",
-  parent: registryBelongsTo("person"),
-  pets: registryHasMany("pet"),
-  friends: registryHasMany<"pet" | "person">({ polymorphic: true }),
+  parent: belongsTo("person"),
+  pets: hasMany("pet"),
+  friends: hasMany<"pet" | "person">({ polymorphic: true }),
+
+  nothing: belongsTo("nonexistent"),
+  muchAdoAboutNothing: hasMany("nonexistent"),
 });
 
 const PetModel = Model.extend({
   name: "fido",
-  owner: registryBelongsTo("person"),
+  owner: belongsTo("person"),
 });
 
 type PersonRegistry = Registry<
@@ -34,6 +27,9 @@ const people = schema.all("person");
 people.length; // $ExpectType number
 people.modelName; // $ExpectType string
 people.models.map((model) => {
+  model.nothing; // $ExpectType unknown
+  model.muchAdoAboutNothing; // $ExpectType Collection<unknown>
+
   model.parent?.name; // $ExpectType string | undefined
   model.parent?.parent?.name; // $ExpectType string | undefined
   model.pets.models[0].name; // $ExpectType string

--- a/types/tests/schema-test.ts
+++ b/types/tests/schema-test.ts
@@ -20,25 +20,25 @@ schema.create("foo", { attr: 123 }); // $ExpectError
 schema.create("foo", { x: true }); // $ExpectError
 schema.create("cow"); // $ExpectError
 
-schema.find("foo", "123"); // $ExpectType ModelInstance<FlattenRelationships<Assign<{}, { attr: string; }>> & FlattenFactoryMethods<Assign<{}, { attr: string; }>>> | null
-schema.find("foo", ["123"]).models[0]; // $ExpectType ModelInstance<FlattenRelationships<Assign<{}, { attr: string; }>> & FlattenFactoryMethods<Assign<{}, { attr: string; }>>>
+schema.find("foo", "123")?.attr; // $ExpectType string | undefined
+schema.find("foo", ["123"]).models[0].attr; // $ExpectType string
 schema.find("cow", "123"); // $ExpectError
 
-schema.findOrCreateBy("foo", { attr: "hi" }); // $ExpectType ModelInstance<FlattenRelationships<Assign<{}, { attr: string; }>> & FlattenFactoryMethods<Assign<{}, { attr: string; }>>>
+schema.findOrCreateBy("foo", { attr: "hi" }).attr; // $ExpectType string
 schema.findOrCreateBy("foo", { bar: true }); // $ExpectError
 schema.findOrCreateBy("cow", { attr: "bar" }); // $ExpectError
 
-schema.where("foo", { attr: "bar" }); // $ExpectType Collection<ModelInstance<FlattenRelationships<Assign<{}, { attr: string; }>> & FlattenFactoryMethods<Assign<{}, { attr: string; }>>>>
+schema.where("foo", { attr: "bar" }).models[0].attr; // $ExpectType string
 schema.where("foo", { bar: true }); // $ExpectError
-schema.where("foo", (foo) => foo.attr === "ok"); // $ExpectType Collection<ModelInstance<FlattenRelationships<Assign<{}, { attr: string; }>> & FlattenFactoryMethods<Assign<{}, { attr: string; }>>>>
+schema.where("foo", (foo) => foo.attr === "ok").models[0].attr; // $ExpectType string
 schema.where("foo", (foo) => foo.x === "ok"); // $ExpectError
 schema.where("cow", { attr: "bar" }); // $ExpectError
 
-schema.all("foo"); // $ExpectType Collection<ModelInstance<FlattenRelationships<Assign<{}, { attr: string; }>> & FlattenFactoryMethods<Assign<{}, { attr: string; }>>>>
+schema.all("foo").models[0].attr; // $ExpectType string
 schema.all("cow"); // $ExpectError
 
-schema.none("foo"); // $ExpectType Collection<ModelInstance<FlattenRelationships<Assign<{}, { attr: string; }>> & FlattenFactoryMethods<Assign<{}, { attr: string; }>>>>
+schema.none("foo").models[0].attr; // $ExpectType string
 schema.none("cow"); // $ExpectError
 
-schema.first("foo"); // $ExpectType ModelInstance<FlattenRelationships<Assign<{}, { attr: string; }>> & FlattenFactoryMethods<Assign<{}, { attr: string; }>>> | null
+schema.first("foo")?.attr; // $ExpectType string | undefined
 schema.first("cow"); // $ExpectError


### PR DESCRIPTION
## Intro

Chatting with @samselikoff yesterday about possible paths forward for #396, I had an 'aha moment' around dealing with the typing for relationships between models. What's currently in place requires some boilerplate to work with TypeScript, in order to introduce registry-aware versions of the `belongsTo` and `hasMany` functions. It's also a bit fragile in the face of highly-interconnected sets of models, as you have to be careful not to trip the typechecker's circular type declaration alarms.

## Changes

This PR addresses both of those problems by reworking the types of relationships not to carry the full type of the model they're related to, but rather only the name of that model in the registry. The actual type is resolved on-demand when the key is referenced, eliminating the risk of the typechecker rejecting your setup due to unbounded type recursion.

The main upshot of this is that TypeScript users can just use `belongsTo` and `hasMany` directly from Mirage, rather than having to do a whole song and dance of defining their registry type and doing `export const belongsTo = Mirage.belongsTo as Mirage.BelongsTo<Registry>;`. If a model name is specified for a relationship that isn't in the instantiating registry, the resulting type will be `unknown`.

## Implementation Details

While the details of this don't matter to the consumer, from the implementation perspective, a composed `Registry` type goes from looking like this:

```ts
type MyRegistry = {
  pet: ModelInstance<{
    name: string;
    owner: ModelInstance<{ name: string; pets: ... }>;
  }>;
  person: ModelInstance<{
    name: string;
    pets: Collection<ModelInstance<{ name: string; owner: ... }>;
  }>;
};
```

To this:

```ts
type MyRegistry = {
  pet: {
    name: string;
    owner: BelongsTo<'person'>;
  };
  person: {
    name: string;
    pets: HasMany<'pet'>;
  }
};
```

And previously, methods that would return `Registry[ModelName]` now return `Instantiate<Registry, ModelName>`, which builds out the appropriate `ModelInstance<...>` type, resolving relationships as necessary.

## Notes

This PR is broken up across two commits, and it'll likely be easier to grok the change looking at them separately. The first introduces an `AnyRegistry` type alias so that we don't have to keep typing `extends Registry<Record<string, ModelDefinition>, Record<string, FactoryDefinition>>` everywhere. The second actually makes the shift to on-demand resolution of relationship types.

/cc @chriskrycho @jamescdavis @zoltan-nz 