### PR TITLE
feat: expose handledRequests method on server instance

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1003,6 +1003,17 @@ export default class Server {
   }
 
   /**
+    Retrieve list of handled requests from configured Pretender instance
+
+    @method handledRequests
+    @public
+  */
+  handledRequests() {
+    const handledRequests = this.pretender.handledRequests;
+    return Array.isArray(handledRequests) ? handledRequests : [];
+  }
+
+  /**
    *
    * @private
    * @hide

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -389,6 +389,9 @@ declare module "miragejs/server" {
 
     /** Shutdown the server and stop intercepting network requests. */
     shutdown(): void;
+
+    /** Handled Requests, according to configured Pretender instance */
+    handledRequests(): Request[];
   }
 }
 

--- a/types/tests/server-test.ts
+++ b/types/tests/server-test.ts
@@ -35,6 +35,8 @@ export default function config(this: Server): void {
   });
 
   this.get("/test/:segment", (schema) => Promise.resolve(schema.create("foo"))); // $ExpectType void
+
+  this.handledRequests() // $ExpectType Request[]
 }
 
 const server = new Server({


### PR DESCRIPTION
While using Mirage in a Typescript codebase, I found myself unable to make the following assertion under test due to a lack of type definitions around `handledRequests` (and other properties on the Pretender instance).

https://miragejs.com/docs/testing/assertions/#asserting-against-handled-requests-and-responses
```js
// Also assert against the HTTP request count & query
let requests = server.pretender.handledRequests
expect(requests).to.have.lengthOf(1)
expect(requests[0].queryParams).to.deep.equal({ "filter[genre]": "Sci-Fi" })
```
My first thought was to update _Pretender's_ type definitions such that Mirage could consume them in a meaningful way, but then – after a brief Twitter conversation with @samselikoff – I entertained the idea of exposing `handledRequests` as a property of the Mirage server itself.

To that end, I've added a new public method to the `Server` class, `handledRequests()`. This method retrieves the collection of requests that Pretender has handled, assuming that the server was configured with `trackRequests: true`, otherwise it returns an empty array. This is a slight abstraction around Pretender's internal implementation, [where they return a `noopArray` in the event that request tracking is disabled.
](https://github.com/pretenderjs/pretender/blob/master/src/index.ts#L16-L18). This felt cumbersome to me, as surely an empty array is indicative of zero requests being made?

```js
// pretender.js
let noopArray = { push: function() {}, length: 0 };
this.handledRequests = shouldNotTrack ? noopArray: [];
```

One open question, though, is how the array of requests returned from `handledRequests()` should be typed. In Pretender, they're using an aggregate interface (`FakeXMLHttpRequest` & `ExtraResponseData`) to [represent such a request](https://github.com/pretenderjs/pretender/blob/master/index.d.ts#L26). For the sake of expediency, I'm leaning on the existing `Request` interface defined in Mirage's type definitons.

I hope this makes sense, and that I haven't totally destroyed the codebase or test suite with this idea.

Cheers.
