### PR TITLE
Introduce `createServer`

### DIFF
--- a/__tests__/internal/unit/server-test.js
+++ b/__tests__/internal/unit/server-test.js
@@ -1,4 +1,5 @@
 import {
+  createServer,
   Server,
   Model,
   Factory,
@@ -31,6 +32,39 @@ describe("Unit | Server", function () {
     expect.assertions(1);
 
     let server = new Server({
+      environment: "development",
+      seeds() {
+        expect(true).toBeTruthy();
+      },
+    });
+
+    server.shutdown();
+  });
+});
+
+describe("Unit | createServer", function () {
+  test("it returns a server instance", () => {
+    let server = createServer();
+
+    expect(server).toBeTruthy();
+
+    server.shutdown();
+  });
+
+  test("routes return pretender handler", () => {
+    let server = createServer({ environment: "test" });
+
+    let handler = server.post("foo");
+
+    expect(handler.numberOfCalls).toBe(0);
+
+    server.shutdown();
+  });
+
+  test("it runs the default scenario in non-test environments", () => {
+    expect.assertions(1);
+
+    let server = createServer({
       environment: "development",
       seeds() {
         expect(true).toBeTruthy();

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@ import IdentityManager from "./identity-manager";
 import association from "./association";
 import trait from "./trait";
 import Response from "./response";
-import Server, { defaultPassthroughs } from "./server";
+import Server, { createServer, defaultPassthroughs } from "./server";
 import Model from "./orm/model";
 import Collection from "./orm/collection";
 import Serializer from "./serializer";
@@ -73,6 +73,7 @@ export {
   hasMany,
   belongsTo,
   defaultPassthroughs,
+  createServer,
   Server,
   Factory,
   IdentityManager,

--- a/lib/server.js
+++ b/lib/server.js
@@ -178,6 +178,31 @@ function extractRouteArguments(args) {
 }
 
 /**
+ * Creates a Server
+ * @param {Object} options Server's configuration object
+ * @param {String} options.urlPrefix The base URL for the routes. Example: `http://miragejs.com`.
+ * @param {String} options.namespace The default namespace for the `Server`. Example: `/api/v1`.
+ * @param {Number} options.timing Default latency for the routes to respond to a request.
+ * @param {String} options.environment Defines the environment of the `Server`.
+ * @param {Boolean} options.trackRequests Pretender `trackRequests`.
+ * @param {Boolean} options.useDefaultPassthroughs True to use mirage provided passthroughs
+ * @param {Boolean} options.logging Set to true or false to explicitly specify logging behavior.
+ * @param {Function} options.seeds Called on the seed phase. Should be used to seed the database.
+ * @param {Function} options.scenarios Alias for seeds.
+ * @param {Function} options.routes Should be used to define server routes.
+ * @param {Function} options.baseConfig Alias for routes.
+ * @param {Object} options.inflector Default inflector (used for pluralization and singularization).
+ * @param {Object} options.identityManagers Database identity managers.
+ * @param {Object} options.models Server models
+ * @param {Object} options.serializers Server serializers
+ * @param {Object} options.factories Server factories
+ * @param {Object} options.pretender Pretender instance
+ */
+export function createServer(options) {
+  return new Server(options);
+}
+
+/**
   The Mirage server.
 
   Note that `this` within your `routes` function refers to the server instance, which is the same instance that `server` refers to in your tests.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -13,7 +13,7 @@ declare module "miragejs" {
     BelongsTo,
     HasMany,
   } from "miragejs/-types";
-  export { Server } from "miragejs/server";
+  export { Server, createServer } from "miragejs/server";
   export { Registry, Instantiate, ModelInstance } from "miragejs/-types";
   export {
     Serializer,
@@ -269,7 +269,10 @@ declare module "miragejs/server" {
     timing?: number;
   }
 
-  export interface ServerConfig {
+  export interface ServerConfig<
+    Models extends AnyModels,
+    Factories extends AnyFactories
+  > {
     urlPrefix?: string;
     fixtures?: any;
     namespace?: string;
@@ -279,24 +282,34 @@ declare module "miragejs/server" {
     useDefaultPassthroughs?: boolean;
     logging?: boolean;
 
-    seeds?: (server: Server) => void;
-    scenarios?: (server: Server) => void;
+    seeds?: (server: Server<MirageRegistry<Models, Factories>>) => void;
+    scenarios?: (server: Server<MirageRegistry<Models, Factories>>) => void;
 
-    routes?: (this: Server) => void;
-    baseConfig?: (this: Server) => void;
-    testConfig?: (this: Server) => void;
+    routes?: (this: Server<MirageRegistry<Models, Factories>>) => void;
+    baseConfig?: (this: Server<MirageRegistry<Models, Factories>>) => void;
+    testConfig?: (this: Server<MirageRegistry<Models, Factories>>) => void;
 
     inflector?: object;
     identityManagers?: IdentityManager;
-    models?: any;
+    models?: Models;
     serializers?: any;
-    factories?: any;
+    factories?: Factories;
 
     pretender?: PretenderServer;
   }
 
+  /**
+   * Starts up a Mirage server with the given configuration.
+   */
+  export function createServer<
+    Models extends AnyModels,
+    Factories extends AnyFactories
+  >(
+    config: ServerConfig<Models, Factories>
+  ): Server<MirageRegistry<Models, Factories>>;
+
   export class Server<Registry extends AnyRegistry = AnyRegistry> {
-    constructor(options?: ServerConfig);
+    constructor(options?: ServerConfig<AnyModels, AnyFactories>);
 
     /** The underlying in-memory database instance for this server. */
     readonly db: Db;

--- a/types/tests/server-test.ts
+++ b/types/tests/server-test.ts
@@ -1,4 +1,13 @@
-import { Response, Server, JSONAPISerializer } from "miragejs";
+import {
+  Response,
+  Server,
+  JSONAPISerializer,
+  createServer,
+  Model,
+  belongsTo,
+  hasMany,
+  Factory,
+} from "miragejs";
 
 export default function config(this: Server): void {
   this.namespace = "foo";
@@ -37,7 +46,11 @@ export default function config(this: Server): void {
   this.get("/test/:segment", (schema) => Promise.resolve(schema.create("foo"))); // $ExpectType void
 }
 
-const server = new Server({
+// In `new Server`, models and factories are untyped, and you can
+// therefore use any model names you want when interacting with the
+// schema; the return values just won't necessarily have a lot of
+// type information.
+new Server({
   serializers: {
     application: JSONAPISerializer,
   },
@@ -50,6 +63,8 @@ const server = new Server({
   },
   routes() {
     this.namespace = "api";
+
+    this.schema.all("asfd"); // $ExpectType Collection<ModelInstance<{}>>
 
     this.get("/todos", () => {
       return {
@@ -69,5 +84,51 @@ const server = new Server({
     this.namespace = "/test-api";
     this.get("/movies");
     this.post("/movies");
+  },
+});
+
+// In contrast to `new Server`, `createServer` is able to infer
+// type info from the models and factories you pass it
+createServer({
+  models: {
+    pet: Model.extend({
+      owner: belongsTo("person"),
+    }),
+    person: Model.extend({
+      children: hasMany("person"),
+      friends: hasMany<"person" | "pet">({ polymorphic: true }),
+    }),
+  },
+
+  factories: {
+    pet: Factory.extend({
+      name: (n: number) => `Pet ${n}`,
+    }),
+    person: Factory.extend({
+      name: (n: number) => `Pet ${n}`,
+    }),
+  },
+
+  routes() {
+    this.get("people/:id", (schema, request) => {
+      let person = this.schema.find("person", request.params.id);
+
+      person?.name; // $ExpectType string | undefined
+
+      let friend = person?.friends.models[0];
+
+      friend?.name; // $ExpectType string | undefined
+      friend?.children; // $ExpectError
+
+      if (friend && "friends" in friend) {
+        friend.children.modelName; // $ExpectType string
+      }
+
+      return person ?? new Response(404);
+    });
+
+    this.get("bad", () => {
+      return this.schema.all("typo"); // $ExpectError
+    });
   },
 });


### PR DESCRIPTION
@samselikoff we had a conversation about this a little over a month ago, and I went and implemented it but then never actually committed the files and opened a pull request 🤦 

This PR introduces a `createServer` function as an alternative to writing `new Server`. While it doesn't add any new functionality, it does have a couple of advantages:
 - It avoids having consumers of the library call a side-effecty constructor (whether that's a code smell or not is a matter of personal opinion, but it's certainly been the topic of lots of angsty blog posts)
 - It allows for type-safe interactions with the server in the context of your config, which was the last lingering topic of discussion in #396.
  In other words, if I write `schema.all('foo')` in a route handler, TypeScript can tell based on the `foo` model/factory I provide what type the result will have. Or, if I haven't provided a `foo` model, it can correctly flag `schema.all('foo')` as an error.

/cc @zoltan-nz @chriskrycho 