### PR TITLE
Mark Mirage as tree-shakable via sideEffects key

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A client-side server to help you build, test and demo your JavaScript app",
   "main": "dist/mirage-cjs.js",
   "module": "dist/mirage-esm.js",
+  "sideEffects": false,
   "types": "types/index.d.ts",
   "keywords": [
     "pretender",


### PR DESCRIPTION
Prior to this change, Webpack (in common tools like Create React App + Vue CLI) would not tree-shake Mirage from production builds, since Mirage does indeed have side effects. However, these side effects are only relevant during development, and should not prevent Mirage from being tree-shaken from production builds.

The `sideEffects` key is an escape hatch and can be used to tell Webpack exactly this. With this change, apps with modern build setups that use Mirage like this

```js
import { Server } from 'miragejs'

if (process.env.NODE_ENV === 'production') {
  new Server()
}
```

should get all of `miragejs` automatically tree-shaken from their production builds!