### PR TITLE
Would be nice to have a findBy in a collection

### DIFF
--- a/lib/orm/collection.js
+++ b/lib/orm/collection.js
@@ -261,7 +261,16 @@ export default class Collection {
 
     return new Collection(this.modelName, filteredModels);
   }
-
+  
+  /**
+    Returns a collection model by specified key.
+    @method findBy
+    @param {STRING} key
+    @param {any} value
+  */
+  findBy(key, value) {
+    return this.models.filter((m)=> m[key] === value)[0];
+  }
   /**
      Returns a new Collection with its models sorted according to the provided [compare function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#Parameters).
 


### PR DESCRIPTION
specifically for hasMany associations - for instance in an ember data model
Model.hasMany('otherModel')

in actual code: Model.otherModels.findBy(something)

in testing mirage collection for hasMany throws an error that findBy is not a function ¯\_(ツ)_/¯