### PR TITLE
Initial support of traits in Typescript

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -115,6 +115,9 @@ declare module "miragejs" {
   export function hasMany<K extends string>(
     options?: RelationshipOptions
   ): HasMany<K>;
+
+  /** Declares traits for Factory */
+  export function trait<Data>(data: Data): Data;
 }
 
 declare module "miragejs/-types" {
@@ -340,7 +343,11 @@ declare module "miragejs/server" {
       K extends keyof Registry,
       Init extends Instantiate<Registry, K>,
       Data extends Partial<Init>
-    >(modelName: K, count: number, data?: Data): Array<Init & Data>;
+    >(
+      modelName: K,
+      count: number,
+      ...data: (Data | keyof Data)[]
+    ): Array<Init & Data>;
 
     /** Handle a GET request to the given path. */
     get(
@@ -512,7 +519,7 @@ declare module "miragejs/orm/schema" {
       Data extends Partial<ModelInitializer<Init>>
     >(
       modelName: K,
-      data?: Data
+      ...data: (Data | keyof Data)[]
     ): Init &
       { [K in keyof Init & keyof Data]: Exclude<Init[K], undefined | null> };
 


### PR DESCRIPTION
In attempt to fix #524 this adds a very simple form of support for traits in Typescript.

Currently missing any handling of trait properties.

Downside of this is that it currently does not handle the traits' added properties.

I attempted to type the trait function and `FlattenFactoryMethods` so I could filter out the trait and instead add the trait's properties. But I couldn't figure it out.

I attempted something like:

```typescript
// Extract factory method return values from a factory definition
type FlattenFactoryMethods<T> = {
  [K in keyof T]: T[K] extends (n: number) => infer V
    ? V
    : T[K] extends (data: {}) => Trait<infer U>
    ? U
    : T[K];
};

type Trait<T extends {} = {}> = T & { __isTrait__: true };
```

This is not part of the PR since I couldn't get it working.