### PR TITLE
Provide additional information to shouldIncludeLinkageData()

### DIFF
--- a/lib/serializers/json-api-serializer.js
+++ b/lib/serializers/json-api-serializer.js
@@ -189,7 +189,7 @@ class JSONAPISerializer extends Serializer {
   getHashForPrimaryResource(resource) {
     this._createRequestedIncludesGraph(resource);
 
-    let resourceHash = this.getHashForResource(resource);
+    let resourceHash = this.getHashForResource(resource, false);
     let hashWithRoot = { data: resourceHash };
     let addToIncludes = this.getAddToIncludesForResource(resource);
 
@@ -198,7 +198,7 @@ class JSONAPISerializer extends Serializer {
 
   getHashForIncludedResource(resource) {
     let serializer = this.serializerFor(resource.modelName);
-    let hash = serializer.getHashForResource(resource);
+    let hash = serializer.getHashForResource(resource, true);
     let hashWithRoot = { included: this.isModel(resource) ? [hash] : hash };
     let addToIncludes = [];
 
@@ -209,13 +209,13 @@ class JSONAPISerializer extends Serializer {
     return [hashWithRoot, addToIncludes];
   }
 
-  getHashForResource(resource) {
+  getHashForResource(resource, isIncludedResource) {
     let hash;
 
     if (this.isModel(resource)) {
-      hash = this.getResourceObjectForModel(resource);
+      hash = this.getResourceObjectForModel(resource, isIncludedResource);
     } else {
-      hash = resource.models.map((m) => this.getResourceObjectForModel(m));
+      hash = resource.models.map((m) => this.getResourceObjectForModel(m, isIncludedResource));
     }
 
     return hash;
@@ -294,7 +294,7 @@ class JSONAPISerializer extends Serializer {
     return includes;
   }
 
-  getResourceObjectForModel(model) {
+  getResourceObjectForModel(model, isIncludedResource) {
     let attrs = this._attrsForModel(model, true);
     delete attrs.id;
 
@@ -304,10 +304,10 @@ class JSONAPISerializer extends Serializer {
       attributes: attrs,
     };
 
-    return this._maybeAddRelationshipsToResourceObjectForModel(hash, model);
+    return this._maybeAddRelationshipsToResourceObjectForModel(hash, model, isIncludedResource);
   }
 
-  _maybeAddRelationshipsToResourceObjectForModel(hash, model) {
+  _maybeAddRelationshipsToResourceObjectForModel(hash, model, isIncludedResource) {
     const relationships = {};
 
     model.associationKeys.forEach((key) => {
@@ -323,7 +323,7 @@ class JSONAPISerializer extends Serializer {
 
       if (
         this.alwaysIncludeLinkageData ||
-        this.shouldIncludeLinkageData(key, model) ||
+        this.shouldIncludeLinkageData(key, model, isIncludedResource) ||
         this._relationshipIsIncludedForModel(key, model)
       ) {
         let data = null;
@@ -600,8 +600,9 @@ class JSONAPISerializer extends Serializer {
 
     ```js
     export default JSONAPISerializer.extend({
-      shouldIncludeLinkageData(relationshipKey, model) {
+      shouldIncludeLinkageData(relationshipKey, model, isIncludedResource) {
         if (relationshipKey === 'author' || relationshipKey === 'ghostWriter') {
+          if (isIncludedResource) return false // if an `author` has a `ghostWriter`, don't serialize
           return true;
         }
         return false;
@@ -612,10 +613,11 @@ class JSONAPISerializer extends Serializer {
     @method shouldIncludeLinkageData
     @param {String} relationshipKey
     @param {Model} model
+    @param {Boolean} isIncludedResource - flag to indicate that this is for a lower-level child resource
     @return {Boolean}
     @public
   */
-  shouldIncludeLinkageData(relationshipKey, model) {
+  shouldIncludeLinkageData(relationshipKey, model, isIncludedResource) {
     return false;
   }
 }


### PR DESCRIPTION
Some server implementations will not serialize all included relationships because this would make for a very large payload.

This PR provides a fix for https://github.com/miragejs/miragejs/issues/548 by adding an isIncludedResource flag when calling shouldIncludeLinkageData. This allows the developer of a mirage implementation to know whether or not an included resource is being requested and can therefore make a decision as to whether or not to serialize that as well.