### PR TITLE
Update identityManagers type signature for ServerConfig, DbClass

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -290,7 +290,9 @@ declare module "miragejs/server" {
     testConfig?: (this: Server<MirageRegistry<Models, Factories>>) => void;
 
     inflector?: object;
-    identityManagers?: IdentityManager;
+    identityManagers?: Partial<
+      Record<keyof Models | "application", typeof IdentityManager>
+    >;
     models?: Models;
     serializers?: any;
     factories?: Factories;
@@ -414,7 +416,10 @@ declare module "miragejs/db" {
   };
 
   class DbClass {
-    constructor(initialData: [], identityManagers?: IdentityManager[]);
+    constructor(
+      initialData: [],
+      identityManagers?: Record<string, IdentityManager>,
+    );
 
     createCollection(name: string, initialData?: any[]): void;
     dump(): void;

--- a/types/tests/server-test.ts
+++ b/types/tests/server-test.ts
@@ -8,6 +8,7 @@ import {
   hasMany,
   Factory,
 } from "miragejs";
+import IdentityManager from 'miragejs/identity-manager';
 
 export default function config(this: Server): void {
   this.namespace = "foo";
@@ -85,11 +86,19 @@ new Server({
     this.get("/movies");
     this.post("/movies");
   },
+
+  identityManagers: {
+    application: IdentityManager,
+  },
 });
 
 // In contrast to `new Server`, `createServer` is able to infer
 // type info from the models and factories you pass it
 createServer({
+  identityManagers: {
+    pet: IdentityManager,
+  },
+
   models: {
     pet: Model.extend({
       owner: belongsTo("person"),


### PR DESCRIPTION
Based on the usage of the `identityManagers` option for creating a Mirage Server, [see the `Db` class](https://github.com/miragejs/miragejs/blob/master/lib/db.js#L171-L187), the type signature for the `ServerConfig` interface has been updated to a Record of model names or 'application'. 