### PR TITLE
Fix DbLookup type for db

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -410,7 +410,7 @@ declare module "miragejs/db" {
   import IdentityManager from "miragejs/identity-manager";
 
   type DbLookup = {
-    [key: string]: DbCollection;
+    [key: string]: ReturnType<DbCollection["all"]> & Omit<DbCollection, "all">;
   };
 
   class DbClass {
@@ -597,7 +597,8 @@ declare module "miragejs/serializer" {
     typeKeyForModel?(model: any): string;
   }
 
-  class JSONAPISerializer extends Serializer
+  class JSONAPISerializer
+    extends Serializer
     implements JSONAPISerializerInterface {
     static extend(
       param?: JSONAPISerializerInterface | {}

--- a/types/tests/overview-test.ts
+++ b/types/tests/overview-test.ts
@@ -72,10 +72,6 @@ new Server({
   routes() {
     this.namespace = "api";
 
-    this.get("/movies", (schema, request) => {
-      return schema.db.movies.all();
-    });
-
     this.get("/movies");
     this.get("/movies/:id");
     this.post("/movies");


### PR DESCRIPTION
There's a small hiccup in the current `DbLookup` type which `db` uses.

Eg. if you have something like `schema.db.model`, the type of the model is `DbCollection` which is actually wrong because of what `db.createCollection` does:

```
      // Public API has a convenient array interface. It comes at the cost of
      // returning a copy of all records to avoid accidental mutations.
      Object.defineProperty(this, name, {
        get() {
          let recordsCopy = newCollection.all();

          [
            "insert",
            "find",
            "findBy",
            "where",
            "update",
            "remove",
            "firstOrCreate",
          ].forEach(function (method) {
            recordsCopy[method] = function () {
              return newCollection[method](...arguments);
            };
          });

          return recordsCopy;
        },
      });
```

There's no `db.model.all()` function as the `DbCollection` type suggests. This PR changes the `DbLookup` type to match the actual implementation.