### PR TITLE
[TS] Basic support for functions in factories

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -137,8 +137,14 @@ declare module "miragejs/-types" {
 
   // Captures the result of a `Factory.extend()` call
   interface FactoryDefinition<Data extends {} = {}> {
-    extend<NewData>(data: NewData): FactoryDefinition<Assign<Data, NewData>>;
+    extend<NewData>(
+      data: WithFactoryMethods<NewData>
+    ): FactoryDefinition<Assign<Data, FlattenFactoryMethods<NewData>>>;
   }
+
+  type WithFactoryMethods<T> = {
+    [K in keyof T]: T[K] | ((n: number) => T[K]);
+  };
 
   // Extract factory method return values from a factory definition
   type FlattenFactoryMethods<T> = {

--- a/types/tests/factory-test.ts
+++ b/types/tests/factory-test.ts
@@ -5,34 +5,82 @@ const PersonModel = Model.extend({
   name: "hello",
 });
 
-const PersonFactory = Factory.extend({
+interface Person {
+  age: number;
+  height: string;
+}
+
+/**
+ * We show two methods of using the factories here:
+ * - For PersonFactoryInferred, we show that we can infer
+ *   the properties from your typedefs. This is appropriate
+ *   if all of the properties on your object can be auto-generated with a factory
+ * - For PersonFactoryExplicit, we demonstrate passing an actual type argument to
+ *   Factory.extend, so that you can have extra properties on the model without having
+ *   to create generators.
+ */
+
+const PersonFactoryInferred = Factory.extend({
   age: 42,
   height(n: number) {
     return `${n}'`;
   },
 });
 
-declare const schema: Schema<Registry<
-  { person: typeof PersonModel },
-  { person: typeof PersonFactory }
->>;
-
-const people = schema.all("person");
-
-people.length; // $ExpectType number
-people.modelName; // $ExpectType string
-people.models.map((model) => {
-  model.id; // $ExpectType string | undefined
-  model.name; // $ExpectType string
-  model.attrs; // $ExpectType Record<string, unknown>
-  model.age; // $ExpectType number
-  model.height; // $ExpectType string
-  model.foo; // $ExpectError
+const PersonFactoryExplicit = Factory.extend<Partial<Person>>({
+  height(n: number) {
+    return `${n}'`;
+  },
 });
 
-schema.create("person").height; // $ExpectType string
-schema.create("person", {}).height; // $ExpectType string
-schema.create("person", { height: "custom" }).height; // $ExpectType string
+declare const schema: Schema<Registry<
+  { personExplicit: typeof PersonModel; personInferred: typeof PersonModel },
+  {
+    personExplicit: typeof PersonFactoryExplicit;
+    personInferred: typeof PersonFactoryInferred;
+  }
+>>;
 
-schema.create("person", { height: 123 }); // $ExpectError
-schema.create("person", { foo: "bar" }); // $ExpectError
+{
+  const people = schema.all("personExplicit");
+
+  people.length; // $ExpectType number
+  people.modelName; // $ExpectType string
+  people.models.map((model) => {
+    model.id; // $ExpectType string | undefined
+    model.name; // $ExpectType string
+    model.attrs; // $ExpectType Record<string, unknown>
+    model.age; // $ExpectType number | undefined
+    model.height; // $ExpectType string | undefined
+    model.foo; // $ExpectError
+  });
+
+  schema.create("personExplicit").height; // $ExpectType string
+  schema.create("personExplicit", {}).height; // $ExpectType string | undefined
+  schema.create("personExplicit", { height: "custom" }).height; // $ExpectType string
+
+  schema.create("personExplicit", { height: 123 }); // $ExpectError
+  schema.create("personExplicit", { foo: "bar" }); // $ExpectError
+}
+
+{
+  const people = schema.all("personInferred");
+
+  people.length; // $ExpectType number
+  people.modelName; // $ExpectType string
+  people.models.map((model) => {
+    model.id; // $ExpectType string | undefined
+    model.name; // $ExpectType string
+    model.attrs; // $ExpectType Record<string, unknown>
+    model.age; // $ExpectType number
+    model.height; // $ExpectType string
+    model.foo; // $ExpectError
+  });
+
+  schema.create("personInferred").height; // $ExpectType string
+  schema.create("personInferred", {}).height; // $ExpectType string
+  schema.create("personInferred", { height: "custom" }).height; // $ExpectType string
+
+  schema.create("personInferred", { height: 123 }); // $ExpectError
+  schema.create("personInferred", { foo: "bar" }); // $ExpectError
+}


### PR DESCRIPTION
There's a small limitation of the current types in that we can't use functions within factory definitions. This fixes it so that we can.

This should fix https://github.com/miragejs/examples/issues/9 by making it so that we don't need to use the property-getter workaround