### PR TITLE
Fix - `db.createCollection()` returns an instance, not `void`

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -422,7 +422,7 @@ declare module "miragejs/db" {
   class DbClass {
     constructor(initialData: [], identityManagers?: IdentityManager[]);
 
-    createCollection(name: string, initialData?: any[]): void;
+    createCollection(name: string, initialData?: any[]): Db;
     dump(): void;
     emptyData(): void;
     loadData(data: any): void;

--- a/types/tests/db-test.ts
+++ b/types/tests/db-test.ts
@@ -17,7 +17,7 @@ interface Movie {
   title: string;
 }
 
-myDb.createCollection("movies", [{ title: "Interstellar" }]); // $ExpectType void
+myDb.createCollection("movies", [{ title: "Interstellar" }]); // $ExpectType Db
 myDb.dump(); // $ExpectType void
 myDb.emptyData(); // $ExpectType void
 myDb.loadData({}); // $ExpectType void


### PR DESCRIPTION
Fix the type returned by the method `db.createCollection()`.

Currently it mentions that `void` is returned, however the actual instance of the db is returned:
https://github.com/miragejs/miragejs/blob/b965b8a058523dac0d6ab4792826887154e25368/lib/db.js#L142