### PR TITLE
Feat: Add ability to include afterCreate in overrides

### DIFF
--- a/__tests__/internal/unit/server-test.js
+++ b/__tests__/internal/unit/server-test.js
@@ -531,6 +531,34 @@ describe("Unit | Server #create", function () {
     server.shutdown();
   });
 
+  test("create allows to apply attr overrides containing afterCreate", () => {
+    let CommentFactory = Factory.extend({
+      content: "content",
+    });
+    let ArticleFactory = Factory.extend({
+      title: "Lorem ipsum",
+    });
+
+    let server = new Server({
+      environment: "test",
+      factories: {
+        article: ArticleFactory,
+        comment: CommentFactory,
+      },
+    });
+
+    let articleWithComments = server.create("article", {
+      afterCreate(article, server) {
+        server.createList("comment", 3, { article });
+      },
+    });
+
+    expect(articleWithComments).toEqual({ id: "1", title: "Lorem ipsum" });
+    expect(server.db.comments).toHaveLength(3);
+
+    server.shutdown();
+  });
+
   test("create throws errors when using trait that is not defined and distinquishes between traits and non-traits", () => {
     let ArticleFactory = Factory.extend({
       title: "Lorem ipsum",

--- a/lib/server.js
+++ b/lib/server.js
@@ -901,7 +901,11 @@ export default class Server {
 
     let OriginalFactory = this.factoryFor(type);
     if (OriginalFactory) {
-      OriginalFactory.extractAfterCreateCallbacks({ traits }).forEach(
+      const afterCreateCallbacks = OriginalFactory.extractAfterCreateCallbacks({ traits })
+      if (overrides && overrides.afterCreate) {
+        afterCreateCallbacks.push(overrides.afterCreate)
+      }
+      afterCreateCallbacks.forEach(
         (afterCreate) => {
           afterCreate(modelOrRecord, this);
         }


### PR DESCRIPTION
This PR adds the ability to have an `afterCreate` function in the overrides passed to server's `create` function. This enables users in a few scenarios:

Overriding a property based on itself:
```
const person = server.create('person', {
  afterCreate(model) {
    const initialsFromName = model.name.split(" ").map(s => s[0]).join('').toUpperCase();
    model.update({ name: initialsFromName });
  }
});
```
Updating partial of a nested property:
```
const person = server.create('person', {
  afterCreate(model) {
    model.update({
      attributes: {
        ...model.attributes,
        age: 100,
      }
    });
  }
});
```
One-off relationships:
```
const person = server.create('person', {
  afterCreate(model, server) {
    server.create('pet', { owner: model });
  }
});
```