### PR TITLE
Add types for collection methods

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -91,6 +91,17 @@ declare module "miragejs" {
     length: number;
     modelName: string;
     models: T[];
+    sort: (sortFunc: (a: T, b: T) => number) => Collection<T>;
+    add: (instance: T) => any;
+    destroy: () => any;
+    filter: (callbackFunc: (item: T) => boolean) => Collection<T>;
+    includes: (item: T) => boolean;
+    mergeCollection: (collection: Collection<T>) => Collection<T>;
+    reload: () => any;
+    remove: (instance: T) => any;
+    save: () => any;
+    slice: (start: number, end: number) => Collection<T>;
+    update: <K extends keyof T>(key: K, value: T[K]) => any;
   }
 
   export interface RelationshipOptions {

--- a/types/tests/collection-test.ts
+++ b/types/tests/collection-test.ts
@@ -1,0 +1,35 @@
+import { Collection } from 'miragejs';
+
+type ModelType = { name: string };
+
+const collection = new Collection<ModelType>();
+
+collection.sort((a, b) => { return a.name.localeCompare(b.name) }) // $ExpectType Collection<ModelType>
+collection.sort((a, b) => { return a.err.localeCompare(b.err) }) // $ExpectError
+
+collection.add({ name: 'Bob' }) // $ExpectType any
+collection.add({ err: 'err' }) // $ExpectError
+
+collection.destroy() // $ExpectType any
+
+collection.filter((item) => item.name === 'Bob') // $ExpectType Collection<ModelType>
+collection.filter((item) => item.err === 'Err') // $ExpectError
+
+collection.includes({ name: 'Bob' }) // $ExpectType boolean
+collection.includes({ err: 'err' }) // $ExpectError
+
+collection.mergeCollection(new Collection<ModelType>()) // $ExpectType Collection<ModelType>
+collection.mergeCollection(new Collection<{ err: string }>()) // $ExpectError
+
+collection.reload() // $ExpectType any
+
+collection.remove({ name: 'Bob' }) // $ExpectType any
+collection.remove({ err: 'Err' }) // $ExpectError
+
+collection.save() // $ExpectType any
+
+collection.slice(0, 1) // $ExpectType Collection<ModelType>
+
+collection.update('name', 'John') // $ExpectType any
+collection.update('name', new Date()) // $ExpectError
+collection.update('err', 'err') // $ExpectError


### PR DESCRIPTION
The Collection class had some missing methods which were in the
documentation. This commit adds those types.

Fixes #863 