### PR TITLE
Add failing test for queryParam passthrough

### DIFF
--- a/__tests__/external/browser-only/passthrough-test.js
+++ b/__tests__/external/browser-only/passthrough-test.js
@@ -157,17 +157,17 @@ describe("External | Browser only | Passthrough", () => {
     server.config({
       routes() {
         this.passthrough((request) => {
-          return request.url.match(/users/);
+          return request.queryParams.skipMirage;
         });
       },
     });
 
-    await expect(fetch("/users?test=withQueryParams")).rejects.toThrow(
+    await expect(fetch("/users?skipMirage=true")).rejects.toThrow(
       "Network request failed"
     );
 
-    await expect(fetch("/movies")).rejects.toThrow(
-      `Mirage: Your app tried to GET '/movies'`
+    await expect(fetch("/users")).rejects.toThrow(
+      `Mirage: Your app tried to GET '/users'`
     );
   });
 


### PR DESCRIPTION
This is a failing test for https://github.com/miragejs/miragejs/issues/359, using the example from the [docs](https://miragejs.com/api/classes/server/#passthrough).