### PR TITLE
Pass array of URLs to block for `logging`

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -30,7 +30,7 @@ function createPretender(server) {
     return new Pretender(
       function () {
         this.passthroughRequest = function (verb, path, request) {
-          if (server.shouldLog()) {
+          if (server.shouldLog(request.url)) {
             console.log(
               `Mirage: Passthrough request for ${verb.toUpperCase()} ${
                 request.url
@@ -40,7 +40,7 @@ function createPretender(server) {
         };
 
         this.handledRequest = function (verb, path, request) {
-          if (server.shouldLog()) {
+          if (server.shouldLog(request.url)) {
             console.groupCollapsed(
               `Mirage: [${request.status}] ${verb.toUpperCase()} ${request.url}`
             );

--- a/lib/server.js
+++ b/lib/server.js
@@ -550,17 +550,19 @@ export default class Server {
   isTest() {
     return this.environment === "test";
   }
-
+  
   /**
     Determines if the server should log.
-
-    @method shouldLog
-    @return The value of this.logging if defined, or false if in the testing environment,
-    true otherwise.
+     @method shouldLog
+    @return If this.logging is an array, false if the host is present in the array,
+    true otherwise. If not an array, the value of this.logging if defined, or false if 
+    in the testing environment, true otherwise.
     @public
     @hide
   */
-  shouldLog() {
+
+  shouldLog(url) {
+    if (Array.isArray(this.logging)) return !this.logging.includes(url);
     return typeof this.logging !== "undefined" ? this.logging : !this.isTest();
   }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -550,7 +550,7 @@ export default class Server {
   isTest() {
     return this.environment === "test";
   }
-  
+
   /**
     Determines if the server should log.
      @method shouldLog


### PR DESCRIPTION
There may be cases where I want Mirage to log passthrough requests, but not for all URLs. The change proposed is to pass an array of "blocked" URLs to the `logging` server property.

It may be counterintuitive to pass an array of URLs to logging to be __blocked__, but I see more common the approach for logging to allow all and deny some URLs than deny all and specify which to allow. `true` and `false` can still be used to do logging independent of URLs.

To Do
- Update MirageJS docs to reflect the change