### PR TITLE
Add type for head request handler

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -396,6 +396,13 @@ declare module "miragejs/server" {
       options?: HandlerOptions
     ): void;
 
+    /** Handle a HEAD request to the given path. */
+    head(
+      path: string,
+      handler?: RouteHandler<Registry>,
+      options?: HandlerOptions
+    ): void;
+
     /** Pass through one or more URLs to make real requests. */
     passthrough(urls?: ((request: Request) => any) | string | string[]): void;
 


### PR DESCRIPTION
I found that miragejs handles `this.head` route handlers just fine, but the signature was missing from the types.  So this adds it.  