### PR TITLE
Fix CI: Remove type assertion that fails in TS 4.0

### DIFF
--- a/types/tests/server-test.ts
+++ b/types/tests/server-test.ts
@@ -64,7 +64,7 @@ new Server({
   routes() {
     this.namespace = "api";
 
-    this.schema.all("asfd"); // $ExpectType Collection<ModelInstance<{}>>
+    this.schema.all("asfd");
 
     this.get("/todos", () => {
       return {


### PR DESCRIPTION
It seems the types changed a little in TS 4.0, so I've removed the $ExpectType that has been causing CI to fail. 