### PR TITLE
Move to github actions for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node_version: [6, 8, 10, 12, 14, 16]
+        node_version: [10, 12, 14, 16]
         include:
           - os: macos-latest
             node_version: 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  lint:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node_version: [16]
+      fail-fast: false
+
+    name: "Lint: node-${{ matrix.node_version }}, ${{ matrix.os }}"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set node version to ${{ matrix.node_version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node_version }}
+          cache: yarn
+      - name: Install dependencies
+        run: yarn install
+      - name: Lint js
+        run: yarn lint
+      - name: Lint typescript definitions
+        run: yarn lint:ts
+      - name: Check prettier
+        run: yarn prettier:check
+
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node_version: [6, 8, 10, 12, 14, 16]
+        include:
+          - os: macos-latest
+            node_version: 14
+          - os: windows-latest
+            node_version: 14
+      fail-fast: true
+
+    name: "Build&Test: node-${{ matrix.node_version }}, ${{ matrix.os }}"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set node version to ${{ matrix.node_version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node_version }}
+          cache: yarn
+      - name: Install dependencies
+        run: yarn install
+      - name: Run tests
+        run: yarn test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,6 @@ jobs:
         include:
           - os: macos-latest
             node_version: 14
-          - os: windows-latest
-            node_version: 14
       fail-fast: false
 
     name: "Build&Test: node-${{ matrix.node_version }}, ${{ matrix.os }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
             node_version: 14
           - os: windows-latest
             node_version: 14
-      fail-fast: true
+      fail-fast: false
 
     name: "Build&Test: node-${{ matrix.node_version }}, ${{ matrix.os }}"
     steps:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "12"
+  - "14"
 
 sudo: false
 dist: trusty
@@ -29,14 +29,7 @@ before_deploy: |
   }
 
 jobs:
-  fail_fast: true
-
   include:
-    - stage: tests
-      env: NAME=tests
-      install: yarn install
-      script: yarn ci
-
     - stage: npm release
       script: skip
       deploy:


### PR DESCRIPTION
Travis has run out of credits, and github actions are more than powerful enough to run linting and tests, and in fact we can run against all the versions of node that are supported, to ensure no breaking changes are made accidentally.  

I've left the release job in travis for now, we can figure out what to do with that before the next time we need to release.