### PR TITLE
Add more useful typescript type for `modelInstance.attrs`

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -266,7 +266,7 @@ declare module "miragejs/-types" {
   /** Represents the type of an instantiated Mirage model.  */
   export type ModelInstance<Data extends {} = {}> = Data & {
     id?: string;
-    attrs: Record<string, unknown>;
+    attrs: Data;
     modelName: string;
 
     /** Persists any updates on this model back to the Mirage database. */

--- a/types/tests/factory-test.ts
+++ b/types/tests/factory-test.ts
@@ -51,7 +51,7 @@ declare const schema: Schema<
   people.models.map((model) => {
     model.id; // $ExpectType string | undefined
     model.name; // $ExpectType string
-    model.attrs; // $ExpectType Record<string, unknown>
+    model.attrs; // $ExpectType { name: string; age?: number | undefined; height?: string | undefined; }
     model.age; // $ExpectType number | undefined
     model.height; // $ExpectType string | undefined
     model.foo; // $ExpectError
@@ -73,7 +73,7 @@ declare const schema: Schema<
   people.models.map((model) => {
     model.id; // $ExpectType string | undefined
     model.name; // $ExpectType string
-    model.attrs; // $ExpectType Record<string, unknown>
+    model.attrs; // $ExpectType { name: string; age: number; height: string; }
     model.age; // $ExpectType number
     model.height; // $ExpectType string
     model.foo; // $ExpectError

--- a/types/tests/model-test.ts
+++ b/types/tests/model-test.ts
@@ -15,7 +15,7 @@ people.models.map((model) => {
   model.id; // $ExpectType string | undefined
   model.name; // $ExpectType string
   model.modelName; // $ExpectType string
-  model.attrs; // $ExpectType Record<string, unknown>
+  model.attrs; // $ExpectType { name: string; }
   model.foo; // $ExpectError
 
   model.save(); // $ExpectType void


### PR DESCRIPTION
I've found that I sometimes need to get the attributes of a model, but typescript was typing as a generic unknown object.  I _think_ we can type it the same as the properties that are added directly to the model itself, based on the wording of https://miragejs.com/api/classes/model/#attrs. 