### PR TITLE
Route handler return types

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![npm version](https://badge.fury.io/js/miragejs.svg)](https://badge.fury.io/js/miragejs)
 ![example workflow](https://github.com/miragejs/miragejs/actions/workflows/.github/workflows/ci.yml/badge.svg)
 
-
 A client-side server to develop, test and prototype your JavaScript app.
 
 ## Documentation

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -264,7 +264,8 @@ declare module "miragejs/-types" {
   export type AnyRegistry = Registry<AnyModels, AnyFactories>;
 
   type MaybePromise<T> = T | PromiseLike<T>;
-  export type AnyResponse = MaybePromise<ModelInstance | Response | object | number | string | boolean | null>
+  type ValidResponse = object | number | string | boolean | null
+  export type AnyResponse = MaybePromise<ModelInstance | Response | ValidResponse | ValidResponse[]>
 
   /** Represents the type of an instantiated Mirage model.  */
   export type ModelInstance<Data extends {} = {}> = Data & {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -264,7 +264,7 @@ declare module "miragejs/-types" {
   export type AnyRegistry = Registry<AnyModels, AnyFactories>;
 
   type MaybePromise<T> = T | PromiseLike<T>;
-  type ValidResponse = object | number | string | boolean | null
+  type ValidResponse = Record<PropertyKey, any> | number | string | boolean | null
   export type AnyResponse = MaybePromise<ModelInstance | Response | ValidResponse | ValidResponse[]>
 
   /** Represents the type of an instantiated Mirage model.  */

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -264,8 +264,15 @@ declare module "miragejs/-types" {
   export type AnyRegistry = Registry<AnyModels, AnyFactories>;
 
   type MaybePromise<T> = T | PromiseLike<T>;
-  type ValidResponse = Record<PropertyKey, any> | number | string | boolean | null
-  export type AnyResponse = MaybePromise<ModelInstance | Response | ValidResponse | ValidResponse[]>
+  type ValidResponse =
+    | Record<PropertyKey, any>
+    | number
+    | string
+    | boolean
+    | null;
+  export type AnyResponse = MaybePromise<
+    ModelInstance | Response | ValidResponse | ValidResponse[]
+  >;
 
   /** Represents the type of an instantiated Mirage model.  */
   export type ModelInstance<Data extends {} = {}> = Data & {
@@ -304,10 +311,10 @@ declare module "miragejs/server" {
   import PretenderServer from "pretender";
 
   /** A callback that will be invoked when a given Mirage route is hit. */
-  export type RouteHandler<Registry extends AnyRegistry, Response extends AnyResponse = AnyResponse> = (
-    schema: Schema<Registry>,
-    request: Request
-  ) => Response;
+  export type RouteHandler<
+    Registry extends AnyRegistry,
+    Response extends AnyResponse = AnyResponse
+  > = (schema: Schema<Registry>, request: Request) => Response;
 
   export interface HandlerOptions {
     /** A number of ms to artificially delay responses to this route. */

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -156,7 +156,7 @@ declare module "miragejs" {
 }
 
 declare module "miragejs/-types" {
-  import { Collection } from "miragejs";
+  import { Collection, Response } from "miragejs";
 
   /* A 1:1 relationship between models */
   export class BelongsTo<Name extends string> {
@@ -263,6 +263,9 @@ declare module "miragejs/-types" {
   /** A marker type for easily constraining type parameters that must be shaped like a Registry */
   export type AnyRegistry = Registry<AnyModels, AnyFactories>;
 
+  type MaybePromise<T> = T | PromiseLike<T>;
+  export type AnyResponse = MaybePromise<ModelInstance | Response | object | number | string | boolean | null>
+
   /** Represents the type of an instantiated Mirage model.  */
   export type ModelInstance<Data extends {} = {}> = Data & {
     id?: string;
@@ -290,6 +293,7 @@ declare module "miragejs/server" {
     AnyRegistry,
     AnyModels,
     AnyFactories,
+    AnyResponse,
     Instantiate,
   } from "miragejs/-types";
   import { ModelInstance } from "miragejs/-types";
@@ -298,13 +302,11 @@ declare module "miragejs/server" {
   import Schema from "miragejs/orm/schema";
   import PretenderServer from "pretender";
 
-  type MaybePromise<T> = T | PromiseLike<T>;
-
   /** A callback that will be invoked when a given Mirage route is hit. */
-  export type RouteHandler<Registry extends AnyRegistry> = (
+  export type RouteHandler<Registry extends AnyRegistry, Response extends AnyResponse = AnyResponse> = (
     schema: Schema<Registry>,
     request: Request
-  ) => MaybePromise<ModelInstance | Response | object>;
+  ) => Response;
 
   export interface HandlerOptions {
     /** A number of ms to artificially delay responses to this route. */
@@ -385,57 +387,57 @@ declare module "miragejs/server" {
     >(modelName: K, count: number, data?: Data): Array<Init & Data>;
 
     /** Handle a GET request to the given path. */
-    get(
+    get<Response extends AnyResponse>(
       path: string,
-      handler?: RouteHandler<Registry>,
+      handler?: RouteHandler<Registry, Response>,
       options?: HandlerOptions
     ): void;
 
     /** Handle a POST request to the given path. */
-    post(
+    post<Response extends AnyResponse>(
       path: string,
-      handler?: RouteHandler<Registry>,
+      handler?: RouteHandler<Registry, Response>,
       options?: HandlerOptions
     ): void;
 
     /** Handle a PUT request to the given path. */
-    put(
+    put<Response extends AnyResponse>(
       path: string,
-      handler?: RouteHandler<Registry>,
+      handler?: RouteHandler<Registry, Response>,
       options?: HandlerOptions
     ): void;
 
     /** Handle a PATCH request to the given path. */
-    patch(
+    patch<Response extends AnyResponse>(
       path: string,
-      handler?: RouteHandler<Registry>,
+      handler?: RouteHandler<Registry, Response>,
       options?: HandlerOptions
     ): void;
 
     /** Handle an OPTIONS request to the given path. */
-    options(
+    options<Response extends AnyResponse>(
       path: string,
-      handler?: RouteHandler<Registry>,
+      handler?: RouteHandler<Registry, Response>,
       options?: HandlerOptions
     ): void;
 
     /** Handle a DELETE request to the given path. */
-    del(
+    del<Response extends AnyResponse>(
       path: string,
-      handler?: RouteHandler<Registry>,
+      handler?: RouteHandler<Registry, Response>,
       options?: HandlerOptions
     ): void;
 
-    delete(
+    delete<Response extends AnyResponse>(
       path: string,
-      handler?: RouteHandler<Registry>,
+      handler?: RouteHandler<Registry, Response>,
       options?: HandlerOptions
     ): void;
 
     /** Handle a HEAD request to the given path. */
-    head(
+    head<Response extends AnyResponse>(
       path: string,
-      handler?: RouteHandler<Registry>,
+      handler?: RouteHandler<Registry, Response>,
       options?: HandlerOptions
     ): void;
 

--- a/types/tests/collection-test.ts
+++ b/types/tests/collection-test.ts
@@ -1,35 +1,39 @@
-import { Collection } from 'miragejs';
+import { Collection } from "miragejs";
 
 type ModelType = { name: string };
 
 const collection = new Collection<ModelType>();
 
-collection.add({ name: 'Bob' }) // $ExpectType Collection<ModelType>
-collection.add({ err: 'err' }) // $ExpectError
+collection.add({ name: "Bob" }); // $ExpectType Collection<ModelType>
+collection.add({ err: "err" }); // $ExpectError
 
-collection.destroy() // $ExpectType Collection<ModelType>
+collection.destroy(); // $ExpectType Collection<ModelType>
 
-collection.filter((item) => item.name === 'Bob') // $ExpectType Collection<ModelType>
-collection.filter((item) => item.err === 'Err') // $ExpectError
+collection.filter((item) => item.name === "Bob"); // $ExpectType Collection<ModelType>
+collection.filter((item) => item.err === "Err"); // $ExpectError
 
-collection.includes({ name: 'Bob' }) // $ExpectType boolean
-collection.includes({ err: 'err' }) // $ExpectError
+collection.includes({ name: "Bob" }); // $ExpectType boolean
+collection.includes({ err: "err" }); // $ExpectError
 
-collection.mergeCollection(new Collection<ModelType>()) // $ExpectType Collection<ModelType>
-collection.mergeCollection(new Collection<{ err: string }>()) // $ExpectError
+collection.mergeCollection(new Collection<ModelType>()); // $ExpectType Collection<ModelType>
+collection.mergeCollection(new Collection<{ err: string }>()); // $ExpectError
 
-collection.reload() // $ExpectType Collection<ModelType>
+collection.reload(); // $ExpectType Collection<ModelType>
 
-collection.remove({ name: 'Bob' }) // $ExpectType Collection<ModelType>
-collection.remove({ err: 'Err' }) // $ExpectError
+collection.remove({ name: "Bob" }); // $ExpectType Collection<ModelType>
+collection.remove({ err: "Err" }); // $ExpectError
 
-collection.save() // $ExpectType Collection<ModelType>
+collection.save(); // $ExpectType Collection<ModelType>
 
-collection.slice(0, 1) // $ExpectType Collection<ModelType>
+collection.slice(0, 1); // $ExpectType Collection<ModelType>
 
-collection.sort((a, b) => { return a.name.localeCompare(b.name) }) // $ExpectType Collection<ModelType>
-collection.sort((a, b) => { return a.err.localeCompare(b.err) }) // $ExpectError
+collection.sort((a, b) => {
+  return a.name.localeCompare(b.name);
+}); // $ExpectType Collection<ModelType>
+collection.sort((a, b) => {
+  return a.err.localeCompare(b.err);
+}); // $ExpectError
 
-collection.update('name', 'John') // $ExpectType Collection<ModelType>
-collection.update('name', new Date()) // $ExpectError
-collection.update('err', 'err') // $ExpectError
+collection.update("name", "John"); // $ExpectType Collection<ModelType>
+collection.update("name", new Date()); // $ExpectError
+collection.update("err", "err"); // $ExpectError

--- a/types/tests/collection-test.ts
+++ b/types/tests/collection-test.ts
@@ -1,39 +1,35 @@
-import { Collection } from "miragejs";
+import { Collection } from 'miragejs';
 
 type ModelType = { name: string };
 
 const collection = new Collection<ModelType>();
 
-collection.add({ name: "Bob" }); // $ExpectType Collection<ModelType>
-collection.add({ err: "err" }); // $ExpectError
+collection.add({ name: 'Bob' }) // $ExpectType Collection<ModelType>
+collection.add({ err: 'err' }) // $ExpectError
 
-collection.destroy(); // $ExpectType Collection<ModelType>
+collection.destroy() // $ExpectType Collection<ModelType>
 
-collection.filter((item) => item.name === "Bob"); // $ExpectType Collection<ModelType>
-collection.filter((item) => item.err === "Err"); // $ExpectError
+collection.filter((item) => item.name === 'Bob') // $ExpectType Collection<ModelType>
+collection.filter((item) => item.err === 'Err') // $ExpectError
 
-collection.includes({ name: "Bob" }); // $ExpectType boolean
-collection.includes({ err: "err" }); // $ExpectError
+collection.includes({ name: 'Bob' }) // $ExpectType boolean
+collection.includes({ err: 'err' }) // $ExpectError
 
-collection.mergeCollection(new Collection<ModelType>()); // $ExpectType Collection<ModelType>
-collection.mergeCollection(new Collection<{ err: string }>()); // $ExpectError
+collection.mergeCollection(new Collection<ModelType>()) // $ExpectType Collection<ModelType>
+collection.mergeCollection(new Collection<{ err: string }>()) // $ExpectError
 
-collection.reload(); // $ExpectType Collection<ModelType>
+collection.reload() // $ExpectType Collection<ModelType>
 
-collection.remove({ name: "Bob" }); // $ExpectType Collection<ModelType>
-collection.remove({ err: "Err" }); // $ExpectError
+collection.remove({ name: 'Bob' }) // $ExpectType Collection<ModelType>
+collection.remove({ err: 'Err' }) // $ExpectError
 
-collection.save(); // $ExpectType Collection<ModelType>
+collection.save() // $ExpectType Collection<ModelType>
 
-collection.slice(0, 1); // $ExpectType Collection<ModelType>
+collection.slice(0, 1) // $ExpectType Collection<ModelType>
 
-collection.sort((a, b) => {
-  return a.name.localeCompare(b.name);
-}); // $ExpectType Collection<ModelType>
-collection.sort((a, b) => {
-  return a.err.localeCompare(b.err);
-}); // $ExpectError
+collection.sort((a, b) => { return a.name.localeCompare(b.name) }) // $ExpectType Collection<ModelType>
+collection.sort((a, b) => { return a.err.localeCompare(b.err) }) // $ExpectError
 
-collection.update("name", "John"); // $ExpectType Collection<ModelType>
-collection.update("name", new Date()); // $ExpectError
-collection.update("err", "err"); // $ExpectError
+collection.update('name', 'John') // $ExpectType Collection<ModelType>
+collection.update('name', new Date()) // $ExpectError
+collection.update('err', 'err') // $ExpectError

--- a/types/tests/server-test.ts
+++ b/types/tests/server-test.ts
@@ -22,6 +22,19 @@ export default function config(this: Server): void {
   this.options("/foo"); // $ExpectType void
   this.del("/foo"); // $ExpectType void
 
+  this.get('/foo', () => ({}))
+  this.get('/foo', () => 0)
+  this.get('/foo', () => 'foo')
+  this.get('/foo', () => true)
+  this.get('/foo', () => null)
+  this.get('/foo', () => ['foo'])
+  this.get('/foo', () => ['foo', 0])
+  this.get<number>('/foo', () => 0)
+  this.get<[number, string]>('/foo', () => [0, 'foo'])
+  
+  this.get<number>('/foo', () => false) // $ExpectError
+  this.get<[number, string]>('/foo', () => ['foo', 0]) // $ExpectError
+
   this.passthrough("/_coverage/upload"); // $ExpectType void
   this.passthrough((request) => request.queryParams.skipMirage); // $ExpectType void
 

--- a/types/tests/server-test.ts
+++ b/types/tests/server-test.ts
@@ -22,18 +22,18 @@ export default function config(this: Server): void {
   this.options("/foo"); // $ExpectType void
   this.del("/foo"); // $ExpectType void
 
-  this.get('/foo', () => ({}))
-  this.get('/foo', () => 0)
-  this.get('/foo', () => 'foo')
-  this.get('/foo', () => true)
-  this.get('/foo', () => null)
-  this.get('/foo', () => ['foo'])
-  this.get('/foo', () => ['foo', 0])
-  this.get<number>('/foo', () => 0)
-  this.get<[number, string]>('/foo', () => [0, 'foo'])
-  
-  this.get<number>('/foo', () => false) // $ExpectError
-  this.get<[number, string]>('/foo', () => ['foo', 0]) // $ExpectError
+  this.get("/foo", () => ({}));
+  this.get("/foo", () => 0);
+  this.get("/foo", () => "foo");
+  this.get("/foo", () => true);
+  this.get("/foo", () => null);
+  this.get("/foo", () => ["foo"]);
+  this.get("/foo", () => ["foo", 0]);
+  this.get<number>("/foo", () => 0);
+  this.get<[number, string]>("/foo", () => [0, "foo"]);
+
+  this.get<number>("/foo", () => false); // $ExpectError
+  this.get<[number, string]>("/foo", () => ["foo", 0]); // $ExpectError
 
   this.passthrough("/_coverage/upload"); // $ExpectType void
   this.passthrough((request) => request.queryParams.skipMirage); // $ExpectType void


### PR DESCRIPTION
This updates the types for `RouteHandler` to allow for any valid JSON response. Adds `number | string | boolean | null` as well as arrays of `object | number | string | boolean | null`.

This is necessary because endpoint can return more than just an object. For instance the project I'm currently working on adding mirage too has an endpoint that returns just a number. Which is totally valid however using the current types without this change causes typescript to emit an error.