### PR TITLE
Enforce prettier in typescript files

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "lint": "eslint .",
     "lint:ts": "dtslint types --expectOnly",
-    "prettier:check": "prettier --list-different '**/*.js'",
+    "prettier:check": "prettier --list-different '**/*{.js,.ts}'",
     "prettier:update": "prettier --write .",
     "dev": "rollup -c -w",
     "build": "rollup -c",

--- a/types/tests/collection-test.ts
+++ b/types/tests/collection-test.ts
@@ -1,35 +1,40 @@
-import { Collection } from 'miragejs';
+import { Collection } from "miragejs";
 
 type ModelType = { name: string };
 
 const collection = new Collection<ModelType>();
 
-collection.add({ name: 'Bob' }) // $ExpectType Collection<ModelType>
-collection.add({ err: 'err' }) // $ExpectError
+collection.add({ name: "Bob" }); // $ExpectType Collection<ModelType>
+collection.add({ err: "err" }); // $ExpectError
 
-collection.destroy() // $ExpectType Collection<ModelType>
+collection.destroy(); // $ExpectType Collection<ModelType>
 
-collection.filter((item) => item.name === 'Bob') // $ExpectType Collection<ModelType>
-collection.filter((item) => item.err === 'Err') // $ExpectError
+collection.filter((item) => item.name === "Bob"); // $ExpectType Collection<ModelType>
+collection.filter((item) => item.err === "Err"); // $ExpectError
 
-collection.includes({ name: 'Bob' }) // $ExpectType boolean
-collection.includes({ err: 'err' }) // $ExpectError
+collection.includes({ name: "Bob" }); // $ExpectType boolean
+collection.includes({ err: "err" }); // $ExpectError
 
-collection.mergeCollection(new Collection<ModelType>()) // $ExpectType Collection<ModelType>
-collection.mergeCollection(new Collection<{ err: string }>()) // $ExpectError
+collection.mergeCollection(new Collection<ModelType>()); // $ExpectType Collection<ModelType>
+collection.mergeCollection(new Collection<{ err: string }>()); // $ExpectError
 
-collection.reload() // $ExpectType Collection<ModelType>
+collection.reload(); // $ExpectType Collection<ModelType>
 
-collection.remove({ name: 'Bob' }) // $ExpectType Collection<ModelType>
-collection.remove({ err: 'Err' }) // $ExpectError
+collection.remove({ name: "Bob" }); // $ExpectType Collection<ModelType>
+collection.remove({ err: "Err" }); // $ExpectError
 
-collection.save() // $ExpectType Collection<ModelType>
+collection.save(); // $ExpectType Collection<ModelType>
 
-collection.slice(0, 1) // $ExpectType Collection<ModelType>
+collection.slice(0, 1); // $ExpectType Collection<ModelType>
 
-collection.sort((a, b) => { return a.name.localeCompare(b.name) }) // $ExpectType Collection<ModelType>
-collection.sort((a, b) => { return a.err.localeCompare(b.err) }) // $ExpectError
+// $ExpectType Collection<ModelType>
+collection.sort((a, b) => {
+  return a.name.localeCompare(b.name);
+});
+collection.sort((a, b) => {
+  return a.err.localeCompare(b.err); // $ExpectError
+});
 
-collection.update('name', 'John') // $ExpectType Collection<ModelType>
-collection.update('name', new Date()) // $ExpectError
-collection.update('err', 'err') // $ExpectError
+collection.update("name", "John"); // $ExpectType Collection<ModelType>
+collection.update("name", new Date()); // $ExpectError
+collection.update("err", "err"); // $ExpectError


### PR DESCRIPTION
`prettier:update` was applied to all files, but `prettier:check` only ran against javascript files, which means that `.ts` files could become incorrectly formatted and CI wouldn't detect it.

This adds typescript files to the formatting check, and formats the only file that was not already conforming to the prettier styles.