### PR TITLE
Type afterCreate in factories

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -156,7 +156,7 @@ declare module "miragejs" {
 }
 
 declare module "miragejs/-types" {
-  import { Collection, Response } from "miragejs";
+  import { Collection, Response, Server } from "miragejs";
 
   /* A 1:1 relationship between models */
   export class BelongsTo<Name extends string> {
@@ -180,13 +180,15 @@ declare module "miragejs/-types" {
     ): FactoryDefinition<Assign<Data, FlattenFactoryMethods<NewData>>>;
   }
 
-  type WithFactoryMethods<T> = {
-    [K in keyof T]: T[K] | ((n: number) => T[K]);
-  };
+  type WithFactoryMethods<T> =
+    | { afterCreate?: (model: ModelInstance<any>, server: Server) => void }
+    | { [K in keyof Omit<T, "afterCreate">]: T[K] | ((n: number) => T[K]) };
 
   // Extract factory method return values from a factory definition
   type FlattenFactoryMethods<T> = {
-    [K in keyof T]: T[K] extends (n: number) => infer V ? V : T[K];
+    [K in keyof Omit<T, "afterCreate">]: T[K] extends (n: number) => infer V
+      ? V
+      : T[K];
   };
 
   /**

--- a/types/tests/factory-test.ts
+++ b/types/tests/factory-test.ts
@@ -1,13 +1,24 @@
-import { Factory, Model, Registry } from "miragejs";
+import { Factory, Model, Registry, belongsTo, Server } from "miragejs";
 import Schema from "miragejs/orm/schema";
 
 const PersonModel = Model.extend({
   name: "hello",
+  address: belongsTo(),
+});
+
+const AddressModel = Model.extend({
+  street: "Meat Street",
+  person: belongsTo(),
 });
 
 interface Person {
   age: number;
   height: string;
+  address: Address;
+}
+
+interface Address {
+  street: string;
 }
 
 /**
@@ -25,6 +36,9 @@ const PersonFactoryInferred = Factory.extend({
   height(n: number) {
     return `${n}'`;
   },
+  aftercreate(person, server: Server) {
+    person.update({ address: server.create("address") });
+  },
 });
 
 const PersonFactoryExplicit = Factory.extend<Partial<Person>>({
@@ -33,15 +47,20 @@ const PersonFactoryExplicit = Factory.extend<Partial<Person>>({
   },
 });
 
-declare const schema: Schema<
-  Registry<
-    { personExplicit: typeof PersonModel; personInferred: typeof PersonModel },
-    {
-      personExplicit: typeof PersonFactoryExplicit;
-      personInferred: typeof PersonFactoryInferred;
-    }
-  >
+type RegistryFixture = Registry<
+  {
+    personExplicit: typeof PersonModel;
+    personInferred: typeof PersonModel;
+    address: typeof AddressModel;
+  },
+  {
+    personExplicit: typeof PersonFactoryExplicit;
+    personInferred: typeof PersonFactoryInferred;
+    address: typeof AddressModel;
+  }
 >;
+
+declare const schema: Schema<RegistryFixture>;
 
 {
   const people = schema.all("personExplicit");


### PR DESCRIPTION
When creating a factory when using typescript, the afterCreate hook
could not be defined as it is not a key of the model. This commit adds
typing for adding the afterCreate hook.

Unfortunately the exact type of the model is not inferred in this
commit. In order to make the factory fully infer the model, we would
need to create a dependency between the factory type and the model type,
which is something that seems to have been avoided purposefully.

IMHO the any model instance works good enough for now.