### PR TITLE
Updates typing for `Request.queryParams`

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -41,7 +41,7 @@ declare module "miragejs" {
     readonly params: Record<string, string>;
 
     /** Any query parameters associated with the request */
-    readonly queryParams: Record<string, string>;
+    readonly queryParams: Record<string, string[] | string | null | undefined>;
   }
 
   /**

--- a/types/tests/server-test.ts
+++ b/types/tests/server-test.ts
@@ -48,7 +48,7 @@ export default function config(this: Server): void {
     schema.db; // $ExpectType Db
 
     request.params; // $ExpectType Record<string, string>
-    request.queryParams; // $ExpectType Record<string, string>
+    request.queryParams; // $ExpectType Record<string, string | string[] | null | undefined>
     request.requestBody; // $ExpectType string
     request.requestHeaders; // $ExpectType Record<string, string>
     request.url; // $ExpectType string
@@ -141,6 +141,7 @@ createServer({
     });
 
     this.get("bad", () => {
+      this.schema.all("typo");
       return this.schema.all("typo"); // $ExpectError
     });
   },

--- a/types/tests/server-test.ts
+++ b/types/tests/server-test.ts
@@ -141,7 +141,6 @@ createServer({
     });
 
     this.get("bad", () => {
-      this.schema.all("typo");
       return this.schema.all("typo"); // $ExpectError
     });
   },


### PR DESCRIPTION
This uses the type from https://github.com/tildeio/route-recognizer/blob/0a44fd86081ef425071839d3184e72fd2916d6fe/lib/route-recognizer.ts#L432 / https://github.com/tildeio/route-recognizer/blob/0a44fd86081ef425071839d3184e72fd2916d6fe/lib/route-recognizer.ts#L454

I think that https://github.com/tildeio/route-recognizer/blob/0a44fd86081ef425071839d3184e72fd2916d6fe/lib/route-recognizer.ts#L161 might contain the correct type for `params` a la #1026 but that seems to need better verification