### PR TITLE
Removed assert about changing Pretender config. Ensured trackRequest was set properly

### DIFF
--- a/lib/mock-server/pretender-config.js
+++ b/lib/mock-server/pretender-config.js
@@ -131,7 +131,8 @@ export default class PretenderConfig {
     }
 
     let didOverridePretenderConfig =
-        config.trackRequests !== undefined && config.trackRequests !== this.trackRequests;
+      config.trackRequests !== undefined &&
+      config.trackRequests !== this.trackRequests;
     assert(
       !didOverridePretenderConfig,
       "You cannot modify Pretender's request tracking once the server is created"

--- a/lib/mock-server/pretender-config.js
+++ b/lib/mock-server/pretender-config.js
@@ -65,9 +65,11 @@ export default class PretenderConfig {
 
   mirageServer;
 
+  trackRequests;
+
   create(mirageServer, config) {
     this.mirageServer = mirageServer;
-    this.pretender = this._create(mirageServer);
+    this.pretender = this._create(mirageServer, config);
 
     /**
      Mirage uses [pretender.js](https://github.com/trek/pretender) as its xhttp interceptor. In your Mirage config, `this.pretender` refers to the actual Pretender instance, so any config options that work there will work here as well.
@@ -129,7 +131,7 @@ export default class PretenderConfig {
     }
 
     let didOverridePretenderConfig =
-      config.trackRequests !== undefined && this.pretender;
+        config.trackRequests !== undefined && config.trackRequests !== this.trackRequests;
     assert(
       !didOverridePretenderConfig,
       "You cannot modify Pretender's request tracking once the server is created"
@@ -233,8 +235,9 @@ export default class PretenderConfig {
    * @return {Object} A new Pretender instance.
    * @public
    */
-  _create(mirageServer) {
+  _create(mirageServer, config) {
     if (typeof window !== "undefined") {
+      this.trackRequests = config.trackRequests || false;
       return new Pretender(
         function () {
           this.passthroughRequest = function (verb, path, request) {
@@ -316,7 +319,7 @@ export default class PretenderConfig {
             );
           };
         },
-        { trackRequests: mirageServer.shouldTrackRequests() }
+        { trackRequests: this.trackRequests }
       );
     }
   }

--- a/lib/server.js
+++ b/lib/server.js
@@ -387,18 +387,6 @@ export default class Server {
   }
 
   /**
-   * Determines if the server should track requests.
-   *
-   * @method shouldTrackRequests
-   * @return The value of this.trackRequests if defined, false otherwise.
-   * @public
-   * @hide
-   */
-  shouldTrackRequests() {
-    return Boolean(this.trackRequests);
-  }
-
-  /**
    * Load the configuration given, setting timing to 0 if in the test
    * environment.
    *


### PR DESCRIPTION
Fixed the assert that informed you could not change the trackRequests after pretender is created. 

After moving things around, the value of tracked Request was being sent into pretender via a function. The value in the function was being set too late. Since the value was already known, just simplified as putting it behind a function served no purpose.

Fixes https://github.com/miragejs/miragejs/issues/1043