### PR TITLE
Fixed timing being incorrectly passed to pretender

### DIFF
--- a/lib/mock-server/pretender-config.js
+++ b/lib/mock-server/pretender-config.js
@@ -2,6 +2,7 @@ import "@miragejs/pretender-node-polyfill/before";
 import Pretender from "pretender";
 import "@miragejs/pretender-node-polyfill/after";
 import assert from "../assert";
+import assign from "lodash.assign";
 
 /**
   Mirage Interceptor Class
@@ -47,10 +48,64 @@ const defaultPassthroughs = [
   },
 ];
 
+const defaultRouteOptions = {
+  coalesce: false,
+  timing: undefined,
+};
+
+/**
+ * Determine if the object contains a valid option.
+ *
+ * @method isOption
+ * @param {Object} option An object with one option value pair.
+ * @return {Boolean} True if option is a valid option, false otherwise.
+ * @private
+ */
+function isOption(option) {
+  if (!option || typeof option !== "object") {
+    return false;
+  }
+
+  let allOptions = Object.keys(defaultRouteOptions);
+  let optionKeys = Object.keys(option);
+  for (let i = 0; i < optionKeys.length; i++) {
+    let key = optionKeys[i];
+    if (allOptions.indexOf(key) > -1) {
+      return true;
+    }
+  }
+  return false;
+}
+
 /**
  @hide
  */
 export { defaultPassthroughs };
+
+/**
+ * Extract arguments for a route.
+ *
+ * @method extractRouteArguments
+ * @param {Array} args Of the form [options], [object, code], [function, code]
+ * [shorthand, options], [shorthand, code, options]
+ * @return {Array} [handler (i.e. the function, object or shorthand), code,
+ * options].
+ */
+function extractRouteArguments(args) {
+  let [lastArg] = args.splice(-1);
+  if (isOption(lastArg)) {
+    lastArg = assign({}, defaultRouteOptions, lastArg);
+  } else {
+    args.push(lastArg);
+    lastArg = defaultRouteOptions;
+  }
+  let t = 2 - args.length;
+  while (t-- > 0) {
+    args.push(undefined);
+  }
+  args.push(lastArg);
+  return args;
+}
 
 export default class PretenderConfig {
   urlPrefix;
@@ -106,10 +161,17 @@ export default class PretenderConfig {
       ["options"],
     ].forEach(([verb, alias]) => {
       this[verb] = (path, ...args) => {
-        let handler = mirageServer.registerRouteHandler(verb, path, args);
+        let [rawHandler, customizedCode, options] = extractRouteArguments(args);
+        let handler = mirageServer.registerRouteHandler(
+          verb,
+          path,
+          rawHandler,
+          customizedCode,
+          options
+        );
         let fullPath = this._getFullPath(path);
         let timing =
-          config.timing !== undefined ? config.timing : () => this.timing;
+          options.timing !== undefined ? options.timing : () => this.timing;
         return this.pretender?.[verb](fullPath, handler, timing);
       };
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -16,62 +16,7 @@ import PretenderConfig from "./mock-server/pretender-config";
 
 const isPluralForModelCache = {};
 
-const defaultRouteOptions = {
-  coalesce: false,
-  timing: undefined,
-};
-
 const defaultInflector = { singularize, pluralize };
-
-/**
- * Determine if the object contains a valid option.
- *
- * @method isOption
- * @param {Object} option An object with one option value pair.
- * @return {Boolean} True if option is a valid option, false otherwise.
- * @private
- */
-function isOption(option) {
-  if (!option || typeof option !== "object") {
-    return false;
-  }
-
-  let allOptions = Object.keys(defaultRouteOptions);
-  let optionKeys = Object.keys(option);
-  for (let i = 0; i < optionKeys.length; i++) {
-    let key = optionKeys[i];
-    if (allOptions.indexOf(key) > -1) {
-      return true;
-    }
-  }
-  return false;
-}
-
-/**
- * Extract arguments for a route.
- *
- * @method extractRouteArguments
- * @param {Array} args Of the form [options], [object, code], [function, code]
- * [shorthand, options], [shorthand, code, options]
- * @return {Array} [handler (i.e. the function, object or shorthand), code,
- * options].
- * @private
- */
-function extractRouteArguments(args) {
-  let [lastArg] = args.splice(-1);
-  if (isOption(lastArg)) {
-    lastArg = assign({}, defaultRouteOptions, lastArg);
-  } else {
-    args.push(lastArg);
-    lastArg = defaultRouteOptions;
-  }
-  let t = 2 - args.length;
-  while (t-- > 0) {
-    args.push(undefined);
-  }
-  args.push(lastArg);
-  return args;
-}
 
 /**
  * Creates a Server
@@ -768,18 +713,7 @@ export default class Server {
     }
   }
 
-  registerRouteHandler(verb, path, args) {
-    let [rawHandler, customizedCode, options] = extractRouteArguments(args);
-    return this._registerRouteHandler(
-      verb,
-      path,
-      rawHandler,
-      customizedCode,
-      options
-    );
-  }
-
-  _registerRouteHandler(verb, path, rawHandler, customizedCode, options) {
+  registerRouteHandler(verb, path, rawHandler, customizedCode, options) {
     let routeHandler = this._container.create("RouteHandler", {
       schema: this.schema,
       verb,


### PR DESCRIPTION
Fixes: https://github.com/miragejs/miragejs/issues/1049

This required a change to the contract for pretender being extracted and updating the extracted pretender. Since we have not removed the internal pretender code yet, this version will work. Should anyone be using the extracted version of pretender at https://github.com/bgantzler/mirage-pretender, that will break until I update that repo as well. Since it hasnt been officially released (waiting for this repo to settle down and shake out bugs, this issue being a prime example), I dont think it will be an issue. 

There were no tests testing this sort of thing to update and I didnt write any as Im not sure exactly how to test it given its the communication between mirage and pretender and kinda happens behind the scenes, which might have been why no tests exist. But since this is a production bug I hope it can be merged anyway. I did install this version in my own app and apply some timings to some of the mirage routes and the tests reacted accordingly. 