### PR TITLE
Add Typescript support for afterCreate

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -158,7 +158,7 @@ declare module "miragejs" {
 }
 
 declare module "miragejs/-types" {
-  import { Collection, Response } from "miragejs";
+  import { Collection, Response, Server } from "miragejs";
 
   /* A 1:1 relationship between models */
   export class BelongsTo<Name extends string> {
@@ -174,11 +174,16 @@ declare module "miragejs/-types" {
   interface ModelDefinition<Data extends {} = {}> {
     extend<NewData>(data: NewData): ModelDefinition<Assign<Data, NewData>>;
   }
+  
+  type AfterCreateFunction<Data, NewData> = (modelOrRecord: ModelInstance<Assign<Data, FlattenFactoryMethods<NewData>>>
+    , server: Server) => void;
 
   // Captures the result of a `Factory.extend()` call
   interface FactoryDefinition<Data extends {} = {}> {
     extend<NewData>(
-      data: WithFactoryMethods<NewData>
+      data: WithFactoryMethods<NewData> & {
+        afterCreate?: AfterCreateFunction<Data, NewData>;
+      }
     ): FactoryDefinition<Assign<Data, FlattenFactoryMethods<NewData>>>;
   }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -175,16 +175,18 @@ declare module "miragejs/-types" {
     extend<NewData>(data: NewData): ModelDefinition<Assign<Data, NewData>>;
   }
   
-  type AfterCreateFunction<Data, NewData> = (modelOrRecord: ModelInstance<Assign<Data, FlattenFactoryMethods<NewData>>>
+  type ExtendedModel<Data, NewData> = Assign<Data, FlattenFactoryMethods<NewData>>;
+  
+  type AfterCreateFunction<Data, NewData> = (modelOrRecord: ModelInstance<ExtendedModel<Data, NewData>>
     , server: Server) => void;
 
-  // Captures the result of a `Factory.extend()` call
+// Captures the result of a `Factory.extend()` call
   interface FactoryDefinition<Data extends {} = {}> {
     extend<NewData>(
       data: WithFactoryMethods<NewData> & {
         afterCreate?: AfterCreateFunction<Data, NewData>;
       }
-    ): FactoryDefinition<Assign<Data, FlattenFactoryMethods<NewData>>>;
+    ): FactoryDefinition<ExtendedModel<Data, NewData>>;
   }
 
   type WithFactoryMethods<T> = {

--- a/types/tests/factory-test.ts
+++ b/types/tests/factory-test.ts
@@ -86,3 +86,16 @@ declare const schema: Schema<
   schema.create("personInferred", { height: 123 }); // $ExpectError
   schema.create("personInferred", { foo: "bar" }); // $ExpectError
 }
+
+{
+  const PersonFactoryWithAfterCreate = Factory.extend<Partial<Person>>({
+    age: 42,
+    afterCreate(person, server) {
+      person.age; // $ExpectType number | undefined
+      person.height; // $ExpectType string | undefined
+      person.foo; // $ExpectError
+      person.age = "42"; // $ExpectError
+      person.height = 42; // $ExpectError
+    }
+  });
+}


### PR DESCRIPTION
To address #1052. Includes a test in `factory-test.ts`.

By the way, in that test file, `// $ExpectError` still shows as a TS error, although that might just be for me in Webstorm. `// @ts-expect-error`, placed above the line, shows no red wavy line. Although I don't know if there's a similar equivalent for `$ExpectType`. @zoltan-nz is there anywhere that these "tests" are run or anything?

I would be happy to swap those error assertions as part of this PR, or alternatively in a separate PR, if you'd like. Let me know!

(🥳 my first OSS PR!)