### PR TITLE
Align passthrough type declaration with implementation

### DIFF
--- a/lib/mock-server/pretender-config.js
+++ b/lib/mock-server/pretender-config.js
@@ -452,7 +452,7 @@ export default class PretenderConfig {
 
       if (paths.length === 0) {
         paths = ["/**", "/"];
-      } else if (Array.isArray(lastArg)) {
+      } else if (paths.length > 1 && Array.isArray(lastArg)) {
         verbs = paths.pop();
       }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-// Minimum TypeScript Version: 3.7
+// Minimum TypeScript Version: 4.2
 
 /*
  * Inspired by Dan Freeman
@@ -298,7 +298,7 @@ declare module "miragejs/-types" {
 }
 
 declare module "miragejs/server" {
-  import { Request, Response, Registry as MirageRegistry } from "miragejs";
+  import { Request, Registry as MirageRegistry } from "miragejs";
   import {
     AnyRegistry,
     AnyModels,
@@ -306,11 +306,26 @@ declare module "miragejs/server" {
     AnyResponse,
     Instantiate,
   } from "miragejs/-types";
-  import { ModelInstance } from "miragejs/-types";
+
   import Db from "miragejs/db";
   import IdentityManager from "miragejs/identity-manager";
   import Schema from "miragejs/orm/schema";
   import PretenderServer from "pretender";
+
+  /**
+   * Possible HTTP verbs
+   * @see https://github.com/pretenderjs/pretender/blob/master/index.d.ts#L13
+   **/
+  type HTTPVerb =
+    | "get"
+    | "put"
+    | "post"
+    | "patch"
+    | "delete"
+    | "options"
+    | "head";
+  type PassthroughUrl = ((request: Request) => any) | string;
+  type PassthroughVerbs = HTTPVerb[];
 
   /** A callback that will be invoked when a given Mirage route is hit. */
   export type RouteHandler<
@@ -454,7 +469,10 @@ declare module "miragejs/server" {
     ): void;
 
     /** Pass through one or more URLs to make real requests. */
-    passthrough(...urls: Array<((request: Request) => any) | string>): void;
+    passthrough(...urls: PassthroughUrl[]): void;
+    passthrough(
+      ...args: [PassthroughUrl, ...PassthroughUrl[], PassthroughVerbs]
+    ): void;
 
     /** Load all available fixture data matching the given name(s). */
     loadFixtures(...names: string[]): void;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -324,7 +324,7 @@ declare module "miragejs/server" {
     | "delete"
     | "options"
     | "head";
-  type PassthroughUrl = ((request: Request) => any) | string;
+  type PassthroughArg = ((request: Request) => any) | string;
   type PassthroughVerbs = HTTPVerb[];
 
   /** A callback that will be invoked when a given Mirage route is hit. */
@@ -469,9 +469,9 @@ declare module "miragejs/server" {
     ): void;
 
     /** Pass through one or more URLs to make real requests. */
-    passthrough(...urls: PassthroughUrl[]): void;
+    passthrough(...urls: PassthroughArg[]): void;
     passthrough(
-      ...args: [PassthroughUrl, ...PassthroughUrl[], PassthroughVerbs]
+      ...args: [PassthroughArg, ...PassthroughArg[], PassthroughVerbs]
     ): void;
 
     /** Load all available fixture data matching the given name(s). */

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -454,7 +454,7 @@ declare module "miragejs/server" {
     ): void;
 
     /** Pass through one or more URLs to make real requests. */
-    passthrough(urls?: ((request: Request) => any) | string | string[]): void;
+    passthrough(...urls: Array<((request: Request) => any) | string>): void;
 
     /** Load all available fixture data matching the given name(s). */
     loadFixtures(...names: string[]): void;

--- a/types/tests/server-test.ts
+++ b/types/tests/server-test.ts
@@ -1,3 +1,4 @@
+// Minimum TypeScript Version: 4.2
 import {
   Response,
   Server,
@@ -36,7 +37,14 @@ export default function config(this: Server): void {
   this.get<[number, string]>("/foo", () => ["foo", 0]); // $ExpectError
 
   this.passthrough("/_coverage/upload"); // $ExpectType void
+  this.passthrough("/_coverage/upload_a", "/_coverage/upload_b"); // $ExpectType void
+  this.passthrough(["/_coverage/upload"]); // $ExpectError
   this.passthrough((request) => request.queryParams.skipMirage); // $ExpectType void
+  this.passthrough("/_coverage/upload", ["get"]); // $ExpectType void
+  // prettier-ignore
+  this.passthrough("/_coverage/upload", (request) => request.queryParams.skipMirage); // $ExpectType void
+  // prettier-ignore
+  this.passthrough("/_coverage/upload", (request) => request.queryParams.skipMirage, ["post"]); // $ExpectType void
 
   this.loadFixtures(); // $ExpectType void
   this.seeds(this); // $ExpectType void

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "es6",
     "lib": ["es6", "dom"],
     "module": "ES6",
+    "types": [],
     "noEmit": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
It seems like passthrough type declaration is incorrect. It suggest that you can pass in array of for e.q strings. When we look on implementation passthrough is implemented as ```passthrough(...paths)```. Fix type. Using ```passthrough(['url1', 'url2'])``` will not work.