### PR TITLE
Improve ModelInstance<Model>.update

### DIFF
--- a/lib/orm/model.js
+++ b/lib/orm/model.js
@@ -143,17 +143,21 @@ class Model {
     Updates the record in the db.
 
     ```js
+    let author = authors.find(1);
+    let followers = users.find([1, 2]);
     let post = blogPosts.find(1);
     post.update('title', 'Hipster ipsum'); // the db was updated
     post.update({
       title: 'Lorem ipsum',
       created_at: 'before it was cool'
     });
+    post.update({ author });
+    post.update({ followers });
     ```
 
     @method update
     @param {String} key
-    @param {String} val
+    @param {any} val
     @return this
     @public
    */

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -282,7 +282,7 @@ declare module "miragejs/-types" {
     ? ElementType[] | Collection<ElementType>
     : Value;
 
-  /** Convert any Collection<ElementType> to ElementType[] */
+  /** Convert any Collection<ElementType> to ElementType[] | Collection<ElementType> */
   type CollectionOrList<Data extends {} = {}> = {
     [K in keyof Data]: CollectionOrListValue<Data[K]>;
   };

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -276,6 +276,13 @@ declare module "miragejs/-types" {
     ModelInstance | Response | ValidResponse | ValidResponse[]
   >;
 
+  type RawDataValue<Value> = Value extends Collection<infer ElementType> ? ElementType[] : Value;
+
+  /** Convert any Collection<ElementType> to ElementType[] */
+  type RawData<Data extends {} = {}> = {
+    [K in keyof Data]: RawDataValue<Data[K]>;
+  };
+
   /** Represents the type of an instantiated Mirage model.  */
   export type ModelInstance<Data extends {} = {}> = Data & {
     id?: string;
@@ -286,8 +293,8 @@ declare module "miragejs/-types" {
     save(): void;
 
     /** Updates and immediately persists a single or multiple attr(s) on this model. */
-    update<K extends keyof Data>(key: K, value: Data[K]): void;
-    update(changes: Partial<Data>): void;
+    update<K extends keyof Data>(key: K, value: RawDataValue<Data[K]>): void;
+    update(changes: Partial<RawData<Data>>): void;
 
     /** Removes this model from the Mirage database. */
     destroy(): void;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -276,11 +276,15 @@ declare module "miragejs/-types" {
     ModelInstance | Response | ValidResponse | ValidResponse[]
   >;
 
-  type RawDataValue<Value> = Value extends Collection<infer ElementType> ? ElementType[] : Value;
+  type CollectionOrListValue<Value> = Value extends Collection<
+    infer ElementType
+  >
+    ? ElementType[] | Collection<ElementType>
+    : Value;
 
   /** Convert any Collection<ElementType> to ElementType[] */
-  type RawData<Data extends {} = {}> = {
-    [K in keyof Data]: RawDataValue<Data[K]>;
+  type CollectionOrList<Data extends {} = {}> = {
+    [K in keyof Data]: CollectionOrListValue<Data[K]>;
   };
 
   /** Represents the type of an instantiated Mirage model.  */
@@ -293,8 +297,11 @@ declare module "miragejs/-types" {
     save(): void;
 
     /** Updates and immediately persists a single or multiple attr(s) on this model. */
-    update<K extends keyof Data>(key: K, value: RawDataValue<Data[K]>): void;
-    update(changes: Partial<RawData<Data>>): void;
+    update<K extends keyof Data>(
+      key: K,
+      value: CollectionOrListValue<Data[K]>
+    ): void;
+    update(changes: Partial<CollectionOrList<Data>>): void;
 
     /** Removes this model from the Mirage database. */
     destroy(): void;

--- a/types/tests/relationships-test.ts
+++ b/types/tests/relationships-test.ts
@@ -72,6 +72,11 @@ const personWithPetsArray = schema.create("person", {
   pets: [pet1, pet2],
 });
 
+personWithPetsArray.update('pets', [pet1]);
+personWithPetsArray.update({
+  pets: [pet1, pet2]
+});
+
 personWithPetsArray.pets.modelName; // $ExpectType string
 
 const personWithPetsCollection = schema.create("person", {

--- a/types/tests/relationships-test.ts
+++ b/types/tests/relationships-test.ts
@@ -1,4 +1,12 @@
-import { belongsTo, hasMany, Model, Registry } from "miragejs";
+import {
+  belongsTo,
+  Collection,
+  hasMany,
+  Instantiate,
+  Model,
+  Registry,
+} from "miragejs";
+import { ModelInstance } from "miragejs/-types";
 import Schema from "miragejs/orm/schema";
 
 const PersonModel = Model.extend({
@@ -72,10 +80,14 @@ const personWithPetsArray = schema.create("person", {
   pets: [pet1, pet2],
 });
 
-personWithPetsArray.update('pets', [pet1]);
+personWithPetsArray.update("pets", [pet1]);
 personWithPetsArray.update({
-  pets: [pet1, pet2]
+  pets: [pet1, pet2],
 });
+personWithPetsArray.update(
+  "pets",
+  new Collection<Instantiate<PersonRegistry, "pet">>()
+);
 
 personWithPetsArray.pets.modelName; // $ExpectType string
 


### PR DESCRIPTION
- Given:
```
type Model =  {
    items: HasMany<Item>
}
```

- Current behavior:
```
ModelInstance<Model>.update({items: [item1, item2]}); // $ExpectError
ModelInstance<Model>.update({items: Collection<Item>});
```

- New behavior:

```
ModelInstance<Model>.update({items: [item1, item2]}); 
ModelInstance<Model>.update({items: Collection<Item>}); 
````

- Motivation: We should be able to use readily available/simple data types to update our models, instead of having to create a new `Collection` first before we can update.
