### PR TITLE
Establish precedence for embed over serializeIds

### DIFF
--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -327,7 +327,7 @@ class Serializer {
       You can also define `embed` as a function so it can be determined dynamically.
     */
     this.embed = this.embed || undefined; // this is just here so I can add the doc comment. Better way?
-    this.embedFn = isFunction(this.embed) ? this.embed : () => !!this.embed;
+    this._embedFn = isFunction(this.embed) ? this.embed : () => !!this.embed;
 
     /**
       Use this to define how your serializer handles serializing relationship keys. It can take one of three values:
@@ -753,25 +753,27 @@ class Serializer {
     let newHash = Object.assign({}, attrs);
 
     if (this.serializeIds === "always") {
-      model.associationKeys.forEach((key) => {
-        let resource = model[key];
-        let association = model.associationFor(key);
+      [...model.associationKeys]
+        .filter((key) => !this._embedFn(key))
+        .forEach((key) => {
+          let resource = model[key];
+          let association = model.associationFor(key);
 
-        if (this.isCollection(resource)) {
-          let formattedKey = this.keyForRelationshipIds(key);
-          newHash[formattedKey] =
-            model[`${this._container.inflector.singularize(key)}Ids`];
-        } else if (this.isModel(resource) && association.isPolymorphic) {
-          let formattedTypeKey = this.keyForPolymorphicForeignKeyType(key);
-          let formattedIdKey = this.keyForPolymorphicForeignKeyId(key);
+          if (this.isCollection(resource)) {
+            let formattedKey = this.keyForRelationshipIds(key);
+            newHash[formattedKey] =
+              model[`${this._container.inflector.singularize(key)}Ids`];
+          } else if (this.isModel(resource) && association.isPolymorphic) {
+            let formattedTypeKey = this.keyForPolymorphicForeignKeyType(key);
+            let formattedIdKey = this.keyForPolymorphicForeignKeyId(key);
 
-          newHash[formattedTypeKey] = model[`${key}Id`].type;
-          newHash[formattedIdKey] = model[`${key}Id`].id;
-        } else if (resource) {
-          let formattedKey = this.keyForForeignKey(key);
-          newHash[formattedKey] = model[`${key}Id`];
-        }
-      });
+            newHash[formattedTypeKey] = model[`${key}Id`].type;
+            newHash[formattedIdKey] = model[`${key}Id`].id;
+          } else if (resource) {
+            let formattedKey = this.keyForForeignKey(key);
+            newHash[formattedKey] = model[`${key}Id`];
+          }
+        });
     } else if (this.serializeIds === "included") {
       this.getKeysForIncluded().forEach((key) => {
         let resource = model[key];
@@ -1116,11 +1118,11 @@ class Serializer {
   }
 
   getKeysForEmbedded() {
-    return this.getAssociationKeys().filter((k) => this.embedFn(k));
+    return this.getAssociationKeys().filter((k) => this._embedFn(k));
   }
 
   getKeysForIncluded() {
-    return this.getAssociationKeys().filter((k) => !this.embedFn(k));
+    return this.getAssociationKeys().filter((k) => !this._embedFn(k));
   }
 
   /**


### PR DESCRIPTION
#850 introduced support for selectively serializing embedded relationships. 

This PR should close #1073 which points out a collision which was also introduced between `serializeIds` (set to `always` as it is in [the `ActiveModelSerializer`](https://github.com/miragejs/miragejs/blob/master/lib/serializers/active-model-serializer.js#L5) and [the `RestSerializer`](https://github.com/miragejs/miragejs/blob/master/lib/serializers/rest-serializer.js#L5)) and the intended new functionality.