### PR TITLE
add Middleware support via `server.middleware = [/*...*/]`

### DIFF
--- a/__tests__/internal/move-after-handle-request/middleware-test.js
+++ b/__tests__/internal/move-after-handle-request/middleware-test.js
@@ -7,129 +7,168 @@ describe("Integration | Middleware", () => {
     server.shutdown();
   });
 
-  test("short-circuits by returning without calling next()", async () => {
-    function shortCircuitingMiddleware() {
-      return () => "from middleware";
-    }
+  describe("#middleware", () => {
+    test("works and only applies to subsequent routes", async () => {
+      function shortCircuitingMiddleware1() {
+        return (schema, request, next) => "from first middleware";
+      }
 
-    server = new Server({
-      environment: "test",
-      models: {
-        user: Model,
-      },
-      routes() {
-        this.namespace = "api";
+      function shortCircuitingMiddleware2() {
+        return (schema, request, next) => "from second middleware";
+      }
 
-        this.withMiddleware([shortCircuitingMiddleware()], () => {
+      server = new Server({
+        environment: "test",
+        models: {
+          user: Model,
+          frog: Model,
+        },
+        routes() {
+          this.namespace = "api";
+
+          this.middleware = [shortCircuitingMiddleware1()];
           this.get("/users");
-        });
-      },
-    });
 
-    server.createList("user", 3);
+          this.middleware = [shortCircuitingMiddleware2()];
+          this.get("/frogs");
+        },
+      });
 
-    let data = await fetch("/api/users").then((res) => res.text());
+      server.createList("user", 3);
 
-    expect(data).toEqual("from middleware");
-  });
+      let users = await fetch("/api/users").then((res) => res.text());
+      let frogs = await fetch("/api/frogs").then((res) => res.text());
 
-  test("calls the route handler by calling next()", async () => {
-    function noopMiddleware() {
-      return (schema, request, next) => next();
-    }
-
-    server = new Server({
-      environment: "test",
-      models: {
-        user: Model,
-      },
-      routes() {
-        this.namespace = "api";
-
-        this.withMiddleware([noopMiddleware()], () => {
-          this.get("/users");
-        });
-      },
-    });
-
-    server.createList("user", 3);
-
-    let data = await fetch("/api/users").then((res) => res.json());
-
-    expect(data).toEqual({
-      users: [{ id: "1" }, { id: "2" }, { id: "3" }],
+      expect(users).toEqual("from first middleware");
+      expect(frogs).toEqual("from second middleware");
     });
   });
 
-  test("works with multiple middleware", async () => {
-    function noopMiddleware() {
-      return (schema, request, next) => next();
-    }
+  describe("#withMiddleware", () => {
+    test("short-circuits by returning without calling next()", async () => {
+      function shortCircuitingMiddleware() {
+        return () => "from middleware";
+      }
 
-    server = new Server({
-      environment: "test",
-      models: {
-        user: Model,
-      },
-      routes() {
-        this.namespace = "api";
+      server = new Server({
+        environment: "test",
+        models: {
+          user: Model,
+        },
+        routes() {
+          this.namespace = "api";
 
-        this.withMiddleware([noopMiddleware(), noopMiddleware()], () => {
-          this.get("/users");
-        });
-      },
+          this.withMiddleware([shortCircuitingMiddleware()], () => {
+            this.get("/users");
+          });
+        },
+      });
+
+      server.createList("user", 3);
+
+      let data = await fetch("/api/users").then((res) => res.text());
+
+      expect(data).toEqual("from middleware");
     });
 
-    server.createList("user", 3);
+    test("calls the route handler by calling next()", async () => {
+      function noopMiddleware() {
+        return (schema, request, next) => next();
+      }
 
-    let data = await fetch("/api/users").then((res) => res.json());
+      server = new Server({
+        environment: "test",
+        models: {
+          user: Model,
+        },
+        routes() {
+          this.namespace = "api";
 
-    expect(data).toEqual({
-      users: [{ id: "1" }, { id: "2" }, { id: "3" }],
+          this.withMiddleware([noopMiddleware()], () => {
+            this.get("/users");
+          });
+        },
+      });
+
+      server.createList("user", 3);
+
+      let data = await fetch("/api/users").then((res) => res.json());
+
+      expect(data).toEqual({
+        users: [{ id: "1" }, { id: "2" }, { id: "3" }],
+      });
     });
-  });
 
-  test("resets the middleware outside the block", async () => {
-    function appendStringMiddleware(str) {
-      return (schema, request, next) => {
-        const response = next();
-        const res =
-          response instanceof Response
-            ? response.toRackResponse()
-            : [200, {}, response];
-        return new Response(res[0], res[1], `${res[2]} ${str}`);
-      };
-    }
+    test("works with multiple middleware", async () => {
+      function noopMiddleware() {
+        return (schema, request, next) => next();
+      }
 
-    server = new Server({
-      environment: "test",
-      models: {
-        level0: Model,
-        level1: Model,
-        level2: Model,
-      },
-      routes() {
-        this.namespace = "api";
+      server = new Server({
+        environment: "test",
+        models: {
+          user: Model,
+        },
+        routes() {
+          this.namespace = "api";
 
-        this.withMiddleware([appendStringMiddleware("A")], () => {
-          this.withMiddleware([appendStringMiddleware("B")], () => {
-            this.get("/level2", () => "level2 response");
+          this.withMiddleware([noopMiddleware(), noopMiddleware()], () => {
+            this.get("/users");
+          });
+        },
+      });
+
+      server.createList("user", 3);
+
+      let data = await fetch("/api/users").then((res) => res.json());
+
+      expect(data).toEqual({
+        users: [{ id: "1" }, { id: "2" }, { id: "3" }],
+      });
+    });
+
+    test("resets the middleware outside the block", async () => {
+      function appendStringMiddleware(str) {
+        return (schema, request, next) => {
+          const response = next();
+          const res =
+            response instanceof Response
+              ? response.toRackResponse()
+              : [200, {}, response];
+          return new Response(res[0], res[1], `${res[2]} ${str}`);
+        };
+      }
+
+      server = new Server({
+        environment: "test",
+        models: {
+          level0: Model,
+          level1: Model,
+          level2: Model,
+        },
+        routes() {
+          this.namespace = "api";
+
+          this.withMiddleware([appendStringMiddleware("A")], () => {
+            this.withMiddleware([appendStringMiddleware("B")], () => {
+              this.get("/level2", () => "level2 response");
+            });
+
+            this.get("/level1", () => "level1 response");
           });
 
-          this.get("/level1", () => "level1 response");
-        });
+          this.get("/level0", () => "level0 response");
+        },
+      });
 
-        this.get("/level0", () => "level0 response");
-      },
+      let data2 = await fetch("/api/level2").then((res) => res.text());
+      expect(data2).toEqual("level2 response B A");
+
+      let data1 = await fetch("/api/level1").then((res) => res.text());
+      expect(data1).toEqual("level1 response A");
+
+      let data0 = await fetch("/api/level0").then((res) => res.text());
+      expect(data0).toEqual("level0 response");
     });
-
-    let data2 = await fetch("/api/level2").then((res) => res.text());
-    expect(data2).toEqual("level2 response B A");
-
-    let data1 = await fetch("/api/level1").then((res) => res.text());
-    expect(data1).toEqual("level1 response A");
-
-    let data0 = await fetch("/api/level0").then((res) => res.text());
-    expect(data0).toEqual("level0 response");
   });
 });

--- a/__tests__/internal/move-after-handle-request/middleware-test.js
+++ b/__tests__/internal/move-after-handle-request/middleware-test.js
@@ -1,0 +1,135 @@
+import { Response, Server, Model } from "miragejs";
+
+describe("Integration | Middleware", () => {
+  let server;
+
+  afterEach(function () {
+    server.shutdown();
+  });
+
+  test("short-circuits by returning without calling next()", async () => {
+    function shortCircuitingMiddleware() {
+      return () => "from middleware";
+    }
+
+    server = new Server({
+      environment: "test",
+      models: {
+        user: Model,
+      },
+      routes() {
+        this.namespace = "api";
+
+        this.withMiddleware([shortCircuitingMiddleware()], () => {
+          this.get("/users");
+        });
+      },
+    });
+
+    server.createList("user", 3);
+
+    let data = await fetch("/api/users").then((res) => res.text());
+
+    expect(data).toEqual("from middleware");
+  });
+
+  test("calls the route handler by calling next()", async () => {
+    function noopMiddleware() {
+      return (schema, request, next) => next();
+    }
+
+    server = new Server({
+      environment: "test",
+      models: {
+        user: Model,
+      },
+      routes() {
+        this.namespace = "api";
+
+        this.withMiddleware([noopMiddleware()], () => {
+          this.get("/users");
+        });
+      },
+    });
+
+    server.createList("user", 3);
+
+    let data = await fetch("/api/users").then((res) => res.json());
+
+    expect(data).toEqual({
+      users: [{ id: "1" }, { id: "2" }, { id: "3" }],
+    });
+  });
+
+  test("works with multiple middleware", async () => {
+    function noopMiddleware() {
+      return (schema, request, next) => next();
+    }
+
+    server = new Server({
+      environment: "test",
+      models: {
+        user: Model,
+      },
+      routes() {
+        this.namespace = "api";
+
+        this.withMiddleware([noopMiddleware(), noopMiddleware()], () => {
+          this.get("/users");
+        });
+      },
+    });
+
+    server.createList("user", 3);
+
+    let data = await fetch("/api/users").then((res) => res.json());
+
+    expect(data).toEqual({
+      users: [{ id: "1" }, { id: "2" }, { id: "3" }],
+    });
+  });
+
+  test("resets the middleware outside the block", async () => {
+    function appendStringMiddleware(str) {
+      return (schema, request, next) => {
+        const response = next();
+        const res =
+          response instanceof Response
+            ? response.toRackResponse()
+            : [200, {}, response];
+        return new Response(res[0], res[1], `${res[2]} ${str}`);
+      };
+    }
+
+    server = new Server({
+      environment: "test",
+      models: {
+        level0: Model,
+        level1: Model,
+        level2: Model,
+      },
+      routes() {
+        this.namespace = "api";
+
+        this.withMiddleware([appendStringMiddleware("A")], () => {
+          this.withMiddleware([appendStringMiddleware("B")], () => {
+            this.get("/level2", () => "level2 response");
+          });
+
+          this.get("/level1", () => "level1 response");
+        });
+
+        this.get("/level0", () => "level0 response");
+      },
+    });
+
+    let data2 = await fetch("/api/level2").then((res) => res.text());
+    expect(data2).toEqual("level2 response B A");
+
+    let data1 = await fetch("/api/level1").then((res) => res.text());
+    expect(data1).toEqual("level1 response A");
+
+    let data0 = await fetch("/api/level0").then((res) => res.text());
+    expect(data0).toEqual("level0 response");
+  });
+});

--- a/__tests__/internal/move-after-handle-request/middleware-test.js
+++ b/__tests__/internal/move-after-handle-request/middleware-test.js
@@ -132,8 +132,8 @@ describe("Integration | Middleware", () => {
             return next(requestFromMiddleware2);
           },
           (schema, req, next) => {
-            // This middleware intentionally doesn't pass a Request into `next`
-            // the prior Request object is expected to make it through to the
+            // This middleware intentionally doesn't pass a Request into `next`.
+            // The prior Request object is expected to make it through to the
             // next handler.
             return next();
           },

--- a/lib/route-handler.js
+++ b/lib/route-handler.js
@@ -97,9 +97,7 @@ export default class RouteHandler {
 
       result = this.handleWithMiddleware(request, [
         ...middleware,
-        () => {
-          return this.handler.handle(request);
-        },
+        (_, req) => this.handler.handle(req),
       ]);
     } catch (e) {
       if (e instanceof MirageError) {
@@ -123,10 +121,10 @@ export default class RouteHandler {
     return this._toMirageResponse(result);
   }
 
-  handleWithMiddleware(request, remainingMiddleware) {
-    const current = remainingMiddleware[0];
-    return current.call(null, this.schema, request, () => {
-      return this.handleWithMiddleware(request, remainingMiddleware.slice(1));
+  handleWithMiddleware(request, middleware) {
+    const [current, ...remaining] = middleware;
+    return current(this.schema, request, (req = request) => {
+      return this.handleWithMiddleware(req, remaining);
     });
   }
 

--- a/lib/route-handler.js
+++ b/lib/route-handler.js
@@ -17,9 +17,17 @@ function createHandler({
   path,
   rawHandler,
   options,
+  middleware,
 }) {
   let handler;
-  let args = [schema, serializerOrRegistry, rawHandler, path, options];
+  let args = [
+    schema,
+    serializerOrRegistry,
+    rawHandler,
+    path,
+    options,
+    middleware,
+  ];
   let type = typeof rawHandler;
 
   if (type === "function") {
@@ -52,10 +60,12 @@ export default class RouteHandler {
     options,
     path,
     serializerOrRegistry,
+    middleware,
   }) {
     this.verb = verb;
     this.customizedCode = customizedCode;
     this.serializerOrRegistry = serializerOrRegistry;
+    this.middleware = middleware || [];
     this.handler = createHandler({
       verb,
       schema,
@@ -67,14 +77,14 @@ export default class RouteHandler {
   }
 
   handle(request) {
-    return this._getMirageResponseForRequest(request)
+    return this._getMirageResponseForRequest(request, this.middleware)
       .then((mirageResponse) => this.serialize(mirageResponse, request))
       .then((serializedMirageResponse) => {
         return serializedMirageResponse.toRackResponse();
       });
   }
 
-  _getMirageResponseForRequest(request) {
+  _getMirageResponseForRequest(request, middleware = []) {
     let result;
     try {
       /*
@@ -85,7 +95,12 @@ export default class RouteHandler {
         this.handler.setRequest(request);
       }
 
-      result = this.handler.handle(request);
+      result = this.handleWithMiddleware(request, [
+        ...middleware,
+        () => {
+          return this.handler.handle(request);
+        },
+      ]);
     } catch (e) {
       if (e instanceof MirageError) {
         result = new Response(500, {}, e);
@@ -106,6 +121,13 @@ export default class RouteHandler {
     }
 
     return this._toMirageResponse(result);
+  }
+
+  handleWithMiddleware(request, remainingMiddleware) {
+    const current = remainingMiddleware[0];
+    return current.call(null, this.schema, request, () => {
+      return this.handleWithMiddleware(request, remainingMiddleware.slice(1));
+    });
   }
 
   _toMirageResponse(result) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -92,6 +92,8 @@ export default class Server {
       @return Schema
     */
     this.schema = this.schema || undefined;
+
+    this.middleware = [];
   }
 
   // todo deprecate following
@@ -713,7 +715,51 @@ export default class Server {
     }
   }
 
-  registerRouteHandler(verb, path, rawHandler, customizedCode, options) {
+  /**
+   * Use the provided middleware for the route handlers defined within the
+   * callback.
+   *
+   * ```js
+   *   // Example middleware which randomly returns a
+   *   // 500 response:
+   *   function random500() {
+   *     return (schema, req, next) => {
+   *       return (Math.random() > 0.7)
+   *         ? new Response(500, {}, 'no')
+   *         : next();
+   *     }
+   *   }
+   *
+   *   // Routes which use the middleware defined above:
+   *   routes() {
+   *     this.withMiddleware([
+   *       random500()
+   *     ], () => {
+   *
+   *        // Regular route handlers go here, e.g.
+   *        server.get('/users', (schema, req) => {
+   *          return new Response(204, {}, null);
+   *        });
+   *
+   *     });
+   *   }
+   * ```
+   */
+  withMiddleware(middleware, cb) {
+    const original = this.middleware;
+    this.middleware = (this.middleware || []).concat(middleware);
+    cb();
+    this.middleware = original;
+  }
+
+  registerRouteHandler(
+    verb,
+    path,
+    rawHandler,
+    customizedCode,
+    options,
+    middleware = this.middleware
+  ) {
     let routeHandler = this._container.create("RouteHandler", {
       schema: this.schema,
       verb,
@@ -722,6 +768,7 @@ export default class Server {
       options,
       path,
       serializerOrRegistry: this.serializerOrRegistry,
+      middleware,
     });
 
     return (request) => {

--- a/lib/server.js
+++ b/lib/server.js
@@ -715,43 +715,6 @@ export default class Server {
     }
   }
 
-  /**
-   * Use the provided middleware for the route handlers defined within the
-   * callback.
-   *
-   * ```js
-   *   // Example middleware which randomly returns a
-   *   // 500 response:
-   *   function random500() {
-   *     return (schema, req, next) => {
-   *       return (Math.random() > 0.7)
-   *         ? new Response(500, {}, 'no')
-   *         : next();
-   *     }
-   *   }
-   *
-   *   // Routes which use the middleware defined above:
-   *   routes() {
-   *     this.withMiddleware([
-   *       random500()
-   *     ], () => {
-   *
-   *        // Regular route handlers go here, e.g.
-   *        server.get('/users', (schema, req) => {
-   *          return new Response(204, {}, null);
-   *        });
-   *
-   *     });
-   *   }
-   * ```
-   */
-  withMiddleware(middleware, cb) {
-    const original = this.middleware;
-    this.middleware = (this.middleware || []).concat(middleware);
-    cb();
-    this.middleware = original;
-  }
-
   registerRouteHandler(
     verb,
     path,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -347,6 +347,15 @@ declare module "miragejs/server" {
     Response extends AnyResponse = AnyResponse
   > = (schema: Schema<Registry>, request: Request) => Response;
 
+  export type Middleware<
+    Registry extends AnyRegistry,
+    Response extends AnyResponse = AnyResponse
+  > = (
+    schema: Schema<Registry>,
+    request: Request,
+    next?: Middleware<Registry, Response>
+  ) => Response;
+
   export interface HandlerOptions {
     /** A number of ms to artificially delay responses to this route. */
     timing?: number;
@@ -511,6 +520,41 @@ declare module "miragejs/server" {
     seeds(server: Server): void;
 
     routes(): void;
+
+    /**
+     * Use the provided middleware for the route handlers defined within the
+     * callback.
+     *
+     * ```js
+     *   // Example middleware which randomly returns a
+     *   // 500 response:
+     *   function random500() {
+     *     return (schema, req, next) => {
+     *       return (Math.random() > 0.7)
+     *         ? new Response(500, {}, 'no')
+     *         : next();
+     *     }
+     *   }
+     *
+     *   // Routes which use the middleware defined above:
+     *   routes() {
+     *     this.withMiddleware([
+     *       random500()
+     *     ], () => {
+     *
+     *        // Regular route handlers go here, e.g.
+     *        server.get('/users', (schema, req) => {
+     *          return new Response(204, {}, null);
+     *        });
+     *
+     *     });
+     *   }
+     * ```
+     */
+    withMiddleware<Response extends AnyResponse>(
+      middleware: Middleware<Registry, Response>[],
+      callback: () => void
+    ): void;
 
     /** Shutdown the server and stop intercepting network requests. */
     shutdown(): void;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -434,6 +434,9 @@ declare module "miragejs/server" {
     /** A default prefix applied to all subsequent route definitions. */
     namespace: string;
 
+    /** A set of middleware applied to all subsequent route definitions. */
+    middleware: Middleware<Registry, Response>[];
+
     /** Sets a string to prefix all route handler URLs with. */
     urlPrefix: string;
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -353,7 +353,7 @@ declare module "miragejs/server" {
   > = (
     schema: Schema<Registry>,
     request: Request,
-    next?: Middleware<Registry, Response>
+    next?: (request?: Request) => Response
   ) => Response;
 
   export interface HandlerOptions {
@@ -434,7 +434,35 @@ declare module "miragejs/server" {
     /** A default prefix applied to all subsequent route definitions. */
     namespace: string;
 
-    /** A set of middleware applied to all subsequent route definitions. */
+    /**
+     * A set of middleware applied to subsequent route definitions.
+     *
+     * Usage:
+     * ```js
+     *   // Example middleware which randomly returns a
+     *   // 500 response:
+     *   function random500() {
+     *     return (schema, req, next) => {
+     *       return (Math.random() > 0.7)
+     *         ? new Response(500, {}, 'no')
+     *         : next();
+     *     }
+     *   }
+     *
+     *   // Routes which use the middleware defined above:
+     *   routes() {
+     *     this.middleware = [
+     *       random500(),
+     *       // ...
+     *     ]
+     *
+     *     server.get('/users', (schema, req) => {
+     *       return new Response(204, {}, null);
+     *     });
+     *   }
+     * ```
+     */
+    /**  */
     middleware: Middleware<Registry, Response>[];
 
     /** Sets a string to prefix all route handler URLs with. */
@@ -523,41 +551,6 @@ declare module "miragejs/server" {
     seeds(server: Server): void;
 
     routes(): void;
-
-    /**
-     * Use the provided middleware for the route handlers defined within the
-     * callback.
-     *
-     * ```js
-     *   // Example middleware which randomly returns a
-     *   // 500 response:
-     *   function random500() {
-     *     return (schema, req, next) => {
-     *       return (Math.random() > 0.7)
-     *         ? new Response(500, {}, 'no')
-     *         : next();
-     *     }
-     *   }
-     *
-     *   // Routes which use the middleware defined above:
-     *   routes() {
-     *     this.withMiddleware([
-     *       random500()
-     *     ], () => {
-     *
-     *        // Regular route handlers go here, e.g.
-     *        server.get('/users', (schema, req) => {
-     *          return new Response(204, {}, null);
-     *        });
-     *
-     *     });
-     *   }
-     * ```
-     */
-    withMiddleware<Response extends AnyResponse>(
-      middleware: Middleware<Registry, Response>[],
-      callback: () => void
-    ): void;
 
     /** Shutdown the server and stop intercepting network requests. */
     shutdown(): void;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -462,7 +462,6 @@ declare module "miragejs/server" {
      *   }
      * ```
      */
-    /**  */
     middleware: Middleware<Registry, Response>[];
 
     /** Sets a string to prefix all route handler URLs with. */


### PR DESCRIPTION
Relating to [Add Middleware support to Mirage #41 ](https://github.com/miragejs/discuss/issues/41).

# Middleware

This PR adds middleware to miragejs via a new `server.midleware = [...]`

Example middleware which randomly returns a 500 response:
```js
  function random500() {
    return (schema, req, next) => {
      return (Math.random() > 0.7)
        ? new Response(500, {}, 'no')
        : next();
    }
  }
```
  
Routes which use the middleware defined above: 
_(Edited to match latest update)_
```js
  routes() {
    this.middleware = [
      random500(),
      addABunchOfResponseHeaders(),
      // more middleware can be added here...
    ]

    // Subsequent routes will have that middleware
    this.get('/users', (schema, req) => {
      return new Response(204, {}, null);
    });

    this.middleware = [
      // differentMiddleware
    ]
     
    this.get('/frogs', (schema, req) => {
      return new Response(204, {}, null);
    });
  }
```
# Not included

1. There's a bit of funkyness when middleware wants to modify the response from a route handler because the route handler might return a `Response` object or it might return something else altogether.  I imagine this could be addressed separately.

2. `async` middleware - again, could be added after (if this is the approach this repo heads in).
