### PR TITLE
Simplify lodash dependencies

### DIFF
--- a/__tests__/external/shared/serializers/base/basic-test.js
+++ b/__tests__/external/shared/serializers/base/basic-test.js
@@ -1,5 +1,5 @@
 import { Server, Model } from "miragejs";
-import uniqBy from "lodash.uniqby";
+import uniqBy from "lodash/uniqBy";
 
 describe("External | Shared | Serializers | Base | Basic", function () {
   let server;

--- a/__tests__/external/shared/serializers/json-api-serializer/associations/key-for-relationship-test.js
+++ b/__tests__/external/shared/serializers/json-api-serializer/associations/key-for-relationship-test.js
@@ -1,5 +1,5 @@
 import { Server, Model, hasMany, JSONAPISerializer } from "miragejs";
-import snakeCase from "lodash.snakecase";
+import snakeCase from "lodash/snakeCase";
 
 describe("External | Shared | Serializers | JSON API Serializer | Key for relationship", () => {
   let server;

--- a/__tests__/external/shared/serializers/json-api-serializer/key-formatting-test.js
+++ b/__tests__/external/shared/serializers/json-api-serializer/key-formatting-test.js
@@ -1,5 +1,5 @@
 import { Server, Model, JSONAPISerializer } from "miragejs";
-import snakeCase from "lodash.snakecase";
+import snakeCase from "lodash/snakeCase";
 
 describe("External | Shared | Serializers | JSON API Serializer | Key Formatting", () => {
   let server;

--- a/__tests__/internal/move-after-handle-request/route-handlers/function-handler/serialize-test.js
+++ b/__tests__/internal/move-after-handle-request/route-handlers/function-handler/serialize-test.js
@@ -1,5 +1,5 @@
 import { Server, Model, Collection, ActiveModelSerializer } from "miragejs";
-import uniqBy from "lodash.uniqby";
+import uniqBy from "lodash/uniqBy";
 
 describe("Integration | Route handlers | Function handler | #serialize", () => {
   let server;

--- a/lib/db-collection.js
+++ b/lib/db-collection.js
@@ -1,4 +1,4 @@
-import isEqual from "lodash.isequal";
+import isEqual from "lodash/isEqual";
 import map from "lodash.map";
 
 function duplicate(data) {

--- a/lib/db-collection.js
+++ b/lib/db-collection.js
@@ -1,5 +1,5 @@
 import isEqual from "lodash/isEqual";
-import map from "lodash.map";
+import map from "lodash/map";
 
 function duplicate(data) {
   if (Array.isArray(data)) {

--- a/lib/db.js
+++ b/lib/db.js
@@ -1,6 +1,6 @@
 import DbCollection from "./db-collection";
 import IdentityManager from "./identity-manager";
-import cloneDeep from "lodash.clonedeep";
+import cloneDeep from "lodash/cloneDeep";
 
 /**
   Your Mirage server has a database which you can interact with in your route handlers. You’ll typically use models to interact with your database data, but you can always reach into the db directly in the event you want more control.

--- a/lib/factory.js
+++ b/lib/factory.js
@@ -1,5 +1,5 @@
 import isPlainObject from "lodash.isplainobject";
-import isFunction from "lodash.isfunction";
+import isFunction from "lodash/isFunction";
 import mapValues from "lodash.mapvalues";
 import referenceSort from "./utils/reference-sort";
 

--- a/lib/factory.js
+++ b/lib/factory.js
@@ -1,4 +1,4 @@
-import isPlainObject from "lodash.isplainobject";
+import isPlainObject from "lodash/isPlainObject";
 import isFunction from "lodash/isFunction";
 import mapValues from "lodash.mapvalues";
 import referenceSort from "./utils/reference-sort";

--- a/lib/factory.js
+++ b/lib/factory.js
@@ -1,6 +1,6 @@
 import isPlainObject from "lodash/isPlainObject";
 import isFunction from "lodash/isFunction";
-import mapValues from "lodash.mapvalues";
+import mapValues from "lodash/mapValues";
 import referenceSort from "./utils/reference-sort";
 
 let Factory = function () {

--- a/lib/mock-server/pretender-config.js
+++ b/lib/mock-server/pretender-config.js
@@ -2,7 +2,7 @@ import "@miragejs/pretender-node-polyfill/before";
 import Pretender from "pretender";
 import "@miragejs/pretender-node-polyfill/after";
 import assert from "../assert";
-import assign from "lodash.assign";
+import assign from "lodash/assign";
 
 /**
   Mirage Interceptor Class

--- a/lib/orm/associations/has-many.js
+++ b/lib/orm/associations/has-many.js
@@ -1,7 +1,7 @@
 import Association from "./association";
 import Collection from "../collection";
 import PolymorphicCollection from "../polymorphic-collection";
-import compact from "lodash.compact";
+import compact from "lodash/compact";
 import { capitalize, camelize } from "../../utils/inflector";
 import assert from "@lib/assert";
 

--- a/lib/orm/collection.js
+++ b/lib/orm/collection.js
@@ -1,5 +1,5 @@
 import assert from "../assert";
-import invokeMap from "lodash.invokemap";
+import invokeMap from "lodash/invokeMap";
 
 /**
   Collections represent arrays of models. They are returned by a hasMany association, or by one of the ModelClass query methods:

--- a/lib/orm/model.js
+++ b/lib/orm/model.js
@@ -5,7 +5,7 @@ import assert from "../assert";
 import Collection from "./collection";
 import PolymorphicCollection from "./polymorphic-collection";
 import values from "lodash.values";
-import compact from "lodash.compact";
+import compact from "lodash/compact";
 
 /**
   Models wrap your database, and allow you to define relationships.

--- a/lib/orm/model.js
+++ b/lib/orm/model.js
@@ -4,7 +4,7 @@ import extend from "../utils/extend";
 import assert from "../assert";
 import Collection from "./collection";
 import PolymorphicCollection from "./polymorphic-collection";
-import values from "lodash.values";
+import values from "lodash/values";
 import compact from "lodash/compact";
 
 /**

--- a/lib/orm/polymorphic-collection.js
+++ b/lib/orm/polymorphic-collection.js
@@ -1,4 +1,4 @@
-import invokeMap from "lodash.invokemap";
+import invokeMap from "lodash/invokeMap";
 import isEqual from "lodash.isequal";
 
 /**

--- a/lib/orm/polymorphic-collection.js
+++ b/lib/orm/polymorphic-collection.js
@@ -1,5 +1,5 @@
 import invokeMap from "lodash/invokeMap";
-import isEqual from "lodash.isequal";
+import isEqual from "lodash/isEqual";
 
 /**
  * An array of models, returned from one of the schema query

--- a/lib/orm/schema.js
+++ b/lib/orm/schema.js
@@ -2,7 +2,7 @@ import { camelize, dasherize } from "../utils/inflector";
 import Association from "./associations/association";
 import Collection from "./collection";
 import assert from "../assert";
-import forIn from "lodash.forin";
+import forIn from "lodash/forIn";
 
 const collectionNameCache = {};
 const internalCollectionNameCache = {};

--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -7,7 +7,7 @@ import assert from "./assert";
 import isFunction from "lodash.isfunction";
 import isEmpty from "lodash.isempty";
 import get from "lodash.get";
-import flatten from "lodash.flatten";
+import flatten from "lodash/flatten";
 import compact from "lodash/compact";
 import uniqBy from "lodash.uniqby";
 

--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -4,7 +4,7 @@ import PolymorphicCollection from "./orm/polymorphic-collection";
 import extend from "./utils/extend";
 import { camelize } from "./utils/inflector";
 import assert from "./assert";
-import isFunction from "lodash.isfunction";
+import isFunction from "lodash/isFunction";
 import isEmpty from "lodash/isEmpty";
 import get from "lodash/get";
 import flatten from "lodash/flatten";

--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -9,7 +9,7 @@ import isEmpty from "lodash/isEmpty";
 import get from "lodash/get";
 import flatten from "lodash/flatten";
 import compact from "lodash/compact";
-import uniqBy from "lodash.uniqby";
+import uniqBy from "lodash/uniqBy";
 
 /**
   Serializers are responsible for formatting your route handler's response.

--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -6,7 +6,7 @@ import { camelize } from "./utils/inflector";
 import assert from "./assert";
 import isFunction from "lodash.isfunction";
 import isEmpty from "lodash.isempty";
-import get from "lodash.get";
+import get from "lodash/get";
 import flatten from "lodash/flatten";
 import compact from "lodash/compact";
 import uniqBy from "lodash.uniqby";

--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -5,7 +5,7 @@ import extend from "./utils/extend";
 import { camelize } from "./utils/inflector";
 import assert from "./assert";
 import isFunction from "lodash.isfunction";
-import isEmpty from "lodash.isempty";
+import isEmpty from "lodash/isEmpty";
 import get from "lodash/get";
 import flatten from "lodash/flatten";
 import compact from "lodash/compact";

--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -8,7 +8,7 @@ import isFunction from "lodash.isfunction";
 import isEmpty from "lodash.isempty";
 import get from "lodash.get";
 import flatten from "lodash.flatten";
-import compact from "lodash.compact";
+import compact from "lodash/compact";
 import uniqBy from "lodash.uniqby";
 
 /**

--- a/lib/serializers/json-api-serializer.js
+++ b/lib/serializers/json-api-serializer.js
@@ -5,7 +5,7 @@ import get from "lodash/get";
 import flatten from "lodash/flatten";
 import compact from "lodash/compact";
 import uniqBy from "lodash.uniqby";
-import isEmpty from "lodash.isempty";
+import isEmpty from "lodash/isEmpty";
 /**
   The JSONAPISerializer. Subclass of Serializer.
 

--- a/lib/serializers/json-api-serializer.js
+++ b/lib/serializers/json-api-serializer.js
@@ -4,7 +4,7 @@ import assert from "../assert";
 import get from "lodash/get";
 import flatten from "lodash/flatten";
 import compact from "lodash/compact";
-import uniqBy from "lodash.uniqby";
+import uniqBy from "lodash/uniqBy";
 import isEmpty from "lodash/isEmpty";
 /**
   The JSONAPISerializer. Subclass of Serializer.

--- a/lib/serializers/json-api-serializer.js
+++ b/lib/serializers/json-api-serializer.js
@@ -3,7 +3,7 @@ import { dasherize, camelize } from "../utils/inflector";
 import assert from "../assert";
 import get from "lodash.get";
 import flatten from "lodash.flatten";
-import compact from "lodash.compact";
+import compact from "lodash/compact";
 import uniqBy from "lodash.uniqby";
 import isEmpty from "lodash.isempty";
 /**

--- a/lib/serializers/json-api-serializer.js
+++ b/lib/serializers/json-api-serializer.js
@@ -2,7 +2,7 @@ import Serializer from "../serializer";
 import { dasherize, camelize } from "../utils/inflector";
 import assert from "../assert";
 import get from "lodash.get";
-import flatten from "lodash.flatten";
+import flatten from "lodash/flatten";
 import compact from "lodash/compact";
 import uniqBy from "lodash.uniqby";
 import isEmpty from "lodash.isempty";

--- a/lib/serializers/json-api-serializer.js
+++ b/lib/serializers/json-api-serializer.js
@@ -1,7 +1,7 @@
 import Serializer from "../serializer";
 import { dasherize, camelize } from "../utils/inflector";
 import assert from "../assert";
-import get from "lodash.get";
+import get from "lodash/get";
 import flatten from "lodash/flatten";
 import compact from "lodash/compact";
 import uniqBy from "lodash.uniqby";

--- a/lib/server.js
+++ b/lib/server.js
@@ -6,7 +6,7 @@ import assert from "./assert";
 import BelongsTo from "./orm/associations/belongs-to";
 import Container from "./container";
 import { singularize, pluralize } from "inflected";
-import pick from "lodash.pick";
+import pick from "lodash/pick";
 import assign from "lodash/assign";
 import find from "lodash/find";
 import isPlainObject from "lodash/isPlainObject";

--- a/lib/server.js
+++ b/lib/server.js
@@ -10,7 +10,7 @@ import pick from "lodash.pick";
 import assign from "lodash/assign";
 import find from "lodash/find";
 import isPlainObject from "lodash.isplainobject";
-import isInteger from "lodash.isinteger";
+import isInteger from "lodash/isInteger";
 
 import PretenderConfig from "./mock-server/pretender-config";
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -9,7 +9,7 @@ import { singularize, pluralize } from "inflected";
 import pick from "lodash.pick";
 import assign from "lodash/assign";
 import find from "lodash/find";
-import isPlainObject from "lodash.isplainobject";
+import isPlainObject from "lodash/isPlainObject";
 import isInteger from "lodash/isInteger";
 
 import PretenderConfig from "./mock-server/pretender-config";

--- a/lib/server.js
+++ b/lib/server.js
@@ -7,7 +7,7 @@ import BelongsTo from "./orm/associations/belongs-to";
 import Container from "./container";
 import { singularize, pluralize } from "inflected";
 import pick from "lodash.pick";
-import assign from "lodash.assign";
+import assign from "lodash/assign";
 import find from "lodash.find";
 import isPlainObject from "lodash.isplainobject";
 import isInteger from "lodash.isinteger";

--- a/lib/server.js
+++ b/lib/server.js
@@ -8,7 +8,7 @@ import Container from "./container";
 import { singularize, pluralize } from "inflected";
 import pick from "lodash.pick";
 import assign from "lodash/assign";
-import find from "lodash.find";
+import find from "lodash/find";
 import isPlainObject from "lodash.isplainobject";
 import isInteger from "lodash.isinteger";
 

--- a/lib/utils/extend.js
+++ b/lib/utils/extend.js
@@ -1,4 +1,4 @@
-import has from "lodash.has";
+import has from "lodash/has";
 
 /**
   @hide

--- a/lib/utils/inflector.js
+++ b/lib/utils/inflector.js
@@ -4,7 +4,7 @@ import {
   camelize as _camelize,
   dasherize as _dasherize,
 } from "inflected";
-import lowerFirst from "lodash.lowerfirst";
+import lowerFirst from "lodash/lowerFirst";
 
 const camelizeCache = {};
 const dasherizeCache = {};

--- a/lib/utils/is-association.js
+++ b/lib/utils/is-association.js
@@ -1,4 +1,4 @@
-import isPlainObject from "lodash.isplainobject";
+import isPlainObject from "lodash/isPlainObject";
 
 /**
   @hide

--- a/lib/utils/reference-sort.js
+++ b/lib/utils/reference-sort.js
@@ -1,6 +1,6 @@
 // jscs:disable disallowVar, requireArrayDestructuring
 import uniq from "lodash.uniq";
-import flatten from "lodash.flatten";
+import flatten from "lodash/flatten";
 /**
   @hide
 */

--- a/lib/utils/reference-sort.js
+++ b/lib/utils/reference-sort.js
@@ -1,5 +1,5 @@
 // jscs:disable disallowVar, requireArrayDestructuring
-import uniq from "lodash.uniq";
+import uniq from "lodash/uniq";
 import flatten from "lodash/flatten";
 /**
   @hide

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "@miragejs/pretender-node-polyfill": "^0.1.0",
     "inflected": "^2.0.4",
     "lodash": "^4.0.0",
-    "lodash.pick": "^4.4.0",
     "lodash.snakecase": "^4.1.1",
     "lodash.uniq": "^4.5.0",
     "lodash.uniqby": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "@miragejs/pretender-node-polyfill": "^0.1.0",
     "inflected": "^2.0.4",
     "lodash": "^4.0.0",
-    "lodash.isempty": "^4.4.0",
     "lodash.isequal": "^4.5.0",
     "lodash.isfunction": "^3.0.9",
     "lodash.isinteger": "^4.0.4",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "@miragejs/pretender-node-polyfill": "^0.1.0",
     "inflected": "^2.0.4",
     "lodash": "^4.0.0",
-    "lodash.lowerfirst": "^4.3.1",
     "lodash.map": "^4.6.0",
     "lodash.mapvalues": "^4.6.0",
     "lodash.pick": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "@miragejs/pretender-node-polyfill": "^0.1.0",
     "inflected": "^2.0.4",
     "lodash": "^4.0.0",
-    "lodash.find": "^4.6.0",
     "lodash.flatten": "^4.4.0",
     "lodash.forin": "^4.4.0",
     "lodash.get": "^4.4.2",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "@miragejs/pretender-node-polyfill": "^0.1.0",
     "inflected": "^2.0.4",
     "lodash": "^4.0.0",
-    "lodash.get": "^4.4.2",
     "lodash.has": "^4.5.2",
     "lodash.invokemap": "^4.6.0",
     "lodash.isempty": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "@miragejs/pretender-node-polyfill": "^0.1.0",
     "inflected": "^2.0.4",
     "lodash": "^4.0.0",
-    "lodash.mapvalues": "^4.6.0",
     "lodash.pick": "^4.4.0",
     "lodash.snakecase": "^4.1.1",
     "lodash.uniq": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "@miragejs/pretender-node-polyfill": "^0.1.0",
     "inflected": "^2.0.4",
     "lodash": "^4.0.0",
-    "lodash.snakecase": "^4.1.1",
     "lodash.uniq": "^4.5.0",
     "lodash.uniqby": "^4.7.0",
     "lodash.values": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "@miragejs/pretender-node-polyfill": "^0.1.0",
     "inflected": "^2.0.4",
     "lodash": "^4.0.0",
-    "lodash.isplainobject": "^4.0.6",
     "lodash.lowerfirst": "^4.3.1",
     "lodash.map": "^4.6.0",
     "lodash.mapvalues": "^4.6.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "@miragejs/pretender-node-polyfill": "^0.1.0",
     "inflected": "^2.0.4",
     "lodash": "^4.0.0",
-    "lodash.values": "^4.3.0",
     "pretender": "^3.4.7"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "@miragejs/pretender-node-polyfill": "^0.1.0",
     "inflected": "^2.0.4",
     "lodash": "^4.0.0",
-    "lodash.uniqby": "^4.7.0",
     "lodash.values": "^4.3.0",
     "pretender": "^3.4.7"
   },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "@miragejs/pretender-node-polyfill": "^0.1.0",
     "inflected": "^2.0.4",
     "lodash": "^4.0.0",
-    "lodash.clonedeep": "^4.5.0",
     "lodash.compact": "^3.0.1",
     "lodash.find": "^4.6.0",
     "lodash.flatten": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "@miragejs/pretender-node-polyfill": "^0.1.0",
     "inflected": "^2.0.4",
     "lodash": "^4.0.0",
-    "lodash.isfunction": "^3.0.9",
     "lodash.isinteger": "^4.0.4",
     "lodash.isplainobject": "^4.0.6",
     "lodash.lowerfirst": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "@miragejs/pretender-node-polyfill": "^0.1.0",
     "inflected": "^2.0.4",
     "lodash": "^4.0.0",
-    "lodash.map": "^4.6.0",
     "lodash.mapvalues": "^4.6.0",
     "lodash.pick": "^4.4.0",
     "lodash.snakecase": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@miragejs/pretender-node-polyfill": "^0.1.0",
     "inflected": "^2.0.4",
-    "lodash.assign": "^4.2.0",
+    "lodash": "^4.0.0",
     "lodash.camelcase": "^4.3.0",
     "lodash.clonedeep": "^4.5.0",
     "lodash.compact": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "@miragejs/pretender-node-polyfill": "^0.1.0",
     "inflected": "^2.0.4",
     "lodash": "^4.0.0",
-    "lodash.forin": "^4.4.0",
     "lodash.get": "^4.4.2",
     "lodash.has": "^4.5.2",
     "lodash.invokemap": "^4.6.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "@miragejs/pretender-node-polyfill": "^0.1.0",
     "inflected": "^2.0.4",
     "lodash": "^4.0.0",
-    "lodash.flatten": "^4.4.0",
     "lodash.forin": "^4.4.0",
     "lodash.get": "^4.4.2",
     "lodash.has": "^4.5.2",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "@miragejs/pretender-node-polyfill": "^0.1.0",
     "inflected": "^2.0.4",
     "lodash": "^4.0.0",
-    "lodash.has": "^4.5.2",
     "lodash.invokemap": "^4.6.0",
     "lodash.isempty": "^4.4.0",
     "lodash.isequal": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "@miragejs/pretender-node-polyfill": "^0.1.0",
     "inflected": "^2.0.4",
     "lodash": "^4.0.0",
-    "lodash.isequal": "^4.5.0",
     "lodash.isfunction": "^3.0.9",
     "lodash.isinteger": "^4.0.4",
     "lodash.isplainobject": "^4.0.6",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "@miragejs/pretender-node-polyfill": "^0.1.0",
     "inflected": "^2.0.4",
     "lodash": "^4.0.0",
-    "lodash.camelcase": "^4.3.0",
     "lodash.clonedeep": "^4.5.0",
     "lodash.compact": "^3.0.1",
     "lodash.find": "^4.6.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "@miragejs/pretender-node-polyfill": "^0.1.0",
     "inflected": "^2.0.4",
     "lodash": "^4.0.0",
-    "lodash.compact": "^3.0.1",
     "lodash.find": "^4.6.0",
     "lodash.flatten": "^4.4.0",
     "lodash.forin": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "@miragejs/pretender-node-polyfill": "^0.1.0",
     "inflected": "^2.0.4",
     "lodash": "^4.0.0",
-    "lodash.isinteger": "^4.0.4",
     "lodash.isplainobject": "^4.0.6",
     "lodash.lowerfirst": "^4.3.1",
     "lodash.map": "^4.6.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "@miragejs/pretender-node-polyfill": "^0.1.0",
     "inflected": "^2.0.4",
     "lodash": "^4.0.0",
-    "lodash.invokemap": "^4.6.0",
     "lodash.isempty": "^4.4.0",
     "lodash.isequal": "^4.5.0",
     "lodash.isfunction": "^3.0.9",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "@miragejs/pretender-node-polyfill": "^0.1.0",
     "inflected": "^2.0.4",
     "lodash": "^4.0.0",
-    "lodash.uniq": "^4.5.0",
     "lodash.uniqby": "^4.7.0",
     "lodash.values": "^4.3.0",
     "pretender": "^3.4.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4467,11 +4467,6 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
-lodash.map@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.map/-/lodash.map-4.6.0.tgz#771ec7839e3473d9c4cde28b19394c3562f4f6d3"
-  integrity sha1-dx7Hg540c9nEzeKLGTlMNWL09tM=
-
 lodash.mapvalues@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz#1bafa5005de9dd6f4f26668c30ca37230cc9689c"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4472,11 +4472,6 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash.snakecase@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz#39d714a35357147837aefd64b5dcbb16becd8f8d"
-  integrity sha1-OdcUo1NXFHg3rv1ktdy7Fr7Nj40=
-
 lodash.truncate@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4477,11 +4477,6 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
 
-lodash.values@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/lodash.values/-/lodash.values-4.3.0.tgz#a3a6c2b0ebecc5c2cba1c17e6e620fe81b53d347"
-  integrity sha1-o6bCsOvsxcLLocF+bmIP6BtT00c=
-
 lodash@^4.0.0, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4467,11 +4467,6 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
-lodash.isequal@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
-  integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
-
 lodash.isfunction@^3.0.9:
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz#06de25df4db327ac931981d1bdb067e5af68d051"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4467,11 +4467,6 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
-lodash.lowerfirst@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/lodash.lowerfirst/-/lodash.lowerfirst-4.3.1.tgz#de3c7b12e02c6524a0059c2f6cb7c5c52655a13d"
-  integrity sha1-3jx7EuAsZSSgBZwvbLfFxSZVoT0=
-
 lodash.map@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.map/-/lodash.map-4.6.0.tgz#771ec7839e3473d9c4cde28b19394c3562f4f6d3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4467,11 +4467,6 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
-lodash.isfunction@^3.0.9:
-  version "3.0.9"
-  resolved "https://registry.yarnpkg.com/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz#06de25df4db327ac931981d1bdb067e5af68d051"
-  integrity sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==
-
 lodash.isinteger@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz#619c0af3d03f8b04c31f5882840b77b11cd68343"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4467,11 +4467,6 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
-lodash.mapvalues@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz#1bafa5005de9dd6f4f26668c30ca37230cc9689c"
-  integrity sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw=
-
 lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4467,11 +4467,6 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
-lodash.get@^4.4.2:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
-  integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
-
 lodash.has@^4.5.2:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.has/-/lodash.has-4.5.2.tgz#d19f4dc1095058cccbe2b0cdf4ee0fe4aa37c862"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4457,11 +4457,6 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-lodash.assign@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
-  integrity sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=
-
 lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
@@ -4587,7 +4582,7 @@ lodash.values@^4.3.0:
   resolved "https://registry.yarnpkg.com/lodash.values/-/lodash.values-4.3.0.tgz#a3a6c2b0ebecc5c2cba1c17e6e620fe81b53d347"
   integrity sha1-o6bCsOvsxcLLocF+bmIP6BtT00c=
 
-lodash@^4.7.0:
+lodash@^4.0.0, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4477,11 +4477,6 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
 
-lodash.uniq@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
-  integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
-
 lodash.uniqby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz#d99c07a669e9e6d24e1362dfe266c67616af1302"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4457,11 +4457,6 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-lodash.camelcase@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
-  integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
-
 lodash.clonedeep@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4467,11 +4467,6 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
-lodash.invokemap@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.invokemap/-/lodash.invokemap-4.6.0.tgz#1748cda5d8b0ef8369c4eb3ec54c21feba1f2d62"
-  integrity sha1-F0jNpdiw74NpxOs+xUwh/rofLWI=
-
 lodash.isempty@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.isempty/-/lodash.isempty-4.4.0.tgz#6f86cbedd8be4ec987be9aaf33c9684db1b31e7e"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4477,11 +4477,6 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
 
-lodash.uniqby@^4.7.0:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz#d99c07a669e9e6d24e1362dfe266c67616af1302"
-  integrity sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=
-
 lodash.values@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.values/-/lodash.values-4.3.0.tgz#a3a6c2b0ebecc5c2cba1c17e6e620fe81b53d347"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4472,11 +4472,6 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash.pick@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
-  integrity sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=
-
 lodash.snakecase@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz#39d714a35357147837aefd64b5dcbb16becd8f8d"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4467,11 +4467,6 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
-lodash.forin@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.forin/-/lodash.forin-4.4.0.tgz#5d3f20ae564011fbe88381f7d98949c9c9519731"
-  integrity sha1-XT8grlZAEfvog4H32YlJyclRlzE=
-
 lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4467,11 +4467,6 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
-lodash.flatten@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
-  integrity sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=
-
 lodash.forin@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.forin/-/lodash.forin-4.4.0.tgz#5d3f20ae564011fbe88381f7d98949c9c9519731"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4467,11 +4467,6 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
-lodash.find@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.find/-/lodash.find-4.6.0.tgz#cb0704d47ab71789ffa0de8b97dd926fb88b13b1"
-  integrity sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E=
-
 lodash.flatten@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4462,11 +4462,6 @@ lodash.clonedeep@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
   integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
 
-lodash.compact@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash.compact/-/lodash.compact-3.0.1.tgz#540ce3837745975807471e16b4a2ba21e7256ca5"
-  integrity sha1-VAzjg3dFl1gHRx4WtKK6IeclbKU=
-
 lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4467,11 +4467,6 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
-lodash.isplainobject@^4.0.6:
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
-  integrity sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=
-
 lodash.lowerfirst@^4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/lodash.lowerfirst/-/lodash.lowerfirst-4.3.1.tgz#de3c7b12e02c6524a0059c2f6cb7c5c52655a13d"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4467,11 +4467,6 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
-lodash.has@^4.5.2:
-  version "4.5.2"
-  resolved "https://registry.yarnpkg.com/lodash.has/-/lodash.has-4.5.2.tgz#d19f4dc1095058cccbe2b0cdf4ee0fe4aa37c862"
-  integrity sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI=
-
 lodash.invokemap@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.invokemap/-/lodash.invokemap-4.6.0.tgz#1748cda5d8b0ef8369c4eb3ec54c21feba1f2d62"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4467,11 +4467,6 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
-lodash.isempty@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.isempty/-/lodash.isempty-4.4.0.tgz#6f86cbedd8be4ec987be9aaf33c9684db1b31e7e"
-  integrity sha1-b4bL7di+TsmHvpqvM8loTbGzHn4=
-
 lodash.isequal@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4467,11 +4467,6 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
-lodash.isinteger@^4.0.4:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz#619c0af3d03f8b04c31f5882840b77b11cd68343"
-  integrity sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=
-
 lodash.isplainobject@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"


### PR DESCRIPTION
The need for using the dedicated `lodash.assign` style dependencies has long since passed, so I have updated all uses to import from the one module and use the path import like this `import assign from 'lodash/assign'`

I have compared the output of the dist folder before and after this change and there are no differences for `esm` and `cjs` but `umd` has shaved off .5 MB from its size 😱 

Master: 
```
➜  miragejs git:(master) ls -l dist 
total 4776
-rw-r--r--  1 mansona  staff   223153 Oct 10 12:10 mirage-cjs.js
-rw-r--r--  1 mansona  staff   404879 Oct 10 12:10 mirage-cjs.js.map
-rw-r--r--  1 mansona  staff   269963 Oct 10 12:10 mirage-esm.js
-rw-r--r--  1 mansona  staff   403613 Oct 10 12:10 mirage-esm.js.map
-rw-r--r--  1 mansona  staff  1136772 Oct 10 12:10 mirage-umd.js
➜  miragejs git:(master) ls -lh dist
total 4776
-rw-r--r--  1 mansona  staff   218K Oct 10 12:10 mirage-cjs.js
-rw-r--r--  1 mansona  staff   395K Oct 10 12:10 mirage-cjs.js.map
-rw-r--r--  1 mansona  staff   264K Oct 10 12:10 mirage-esm.js
-rw-r--r--  1 mansona  staff   394K Oct 10 12:10 mirage-esm.js.map
-rw-r--r--  1 mansona  staff   1.1M Oct 10 12:10 mirage-umd.js
```

This branch: 

```
➜  miragejs git:(lodash) ls -l dist
total 3904
-rw-r--r--  1 mansona  staff  223153 Oct 10 12:11 mirage-cjs.js
-rw-r--r--  1 mansona  staff  404879 Oct 10 12:11 mirage-cjs.js.map
-rw-r--r--  1 mansona  staff  269963 Oct 10 12:11 mirage-esm.js
-rw-r--r--  1 mansona  staff  403613 Oct 10 12:11 mirage-esm.js.map
-rw-r--r--  1 mansona  staff  690701 Oct 10 12:11 mirage-umd.js
➜  miragejs git:(lodash) ls -lh dist
total 3904
-rw-r--r--  1 mansona  staff   218K Oct 10 12:11 mirage-cjs.js
-rw-r--r--  1 mansona  staff   395K Oct 10 12:11 mirage-cjs.js.map
-rw-r--r--  1 mansona  staff   264K Oct 10 12:11 mirage-esm.js
-rw-r--r--  1 mansona  staff   394K Oct 10 12:11 mirage-esm.js.map
-rw-r--r--  1 mansona  staff   675K Oct 10 12:11 mirage-umd.js
```