### PR TITLE
add tests for async middleware

### DIFF
--- a/__tests__/internal/move-after-handle-request/middleware-async-test.js
+++ b/__tests__/internal/move-after-handle-request/middleware-async-test.js
@@ -1,0 +1,98 @@
+import { Server } from "miragejs";
+
+async function asynchronousTask(cb) {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve(cb());
+    }, 0);
+  });
+}
+
+describe("Integration | Middleware | async", () => {
+  let server;
+
+  afterEach(function () {
+    server.shutdown();
+  });
+
+  test("await call BEFORE calling next()", async () => {
+    const middlewareBefore = async (schema, req, next) => {
+      await asynchronousTask(() => (req.queryParams.taskDone = "1"));
+      return next();
+    };
+
+    server = new Server({
+      environment: "test",
+      routes() {
+        this.middleware = [middlewareBefore];
+        this.get("/path", (schema, req) => {
+          return req.queryParams.taskDone ? "yay" : "boo";
+        });
+      },
+    });
+
+    let data = await fetch("/path").then((res) => res.text());
+    expect(data).toEqual("yay");
+  });
+
+  test("await call AFTER calling next()", async () => {
+    const middlewareAfter = async (schema, req, next) => {
+      await next();
+      return await asynchronousTask(() => "yay");
+    };
+
+    server = new Server({
+      environment: "test",
+      routes() {
+        this.middleware = [middlewareAfter];
+        this.get("/path", (schema, req) => {
+          return "boo";
+        });
+      },
+    });
+
+    let data = await fetch("/path").then((res) => res.text());
+    expect(data).toEqual("yay");
+  });
+
+  test("asynchronous callback BEFORE calling next()", async () => {
+    const middleware = (schema, req, next) => {
+      return asynchronousTask(
+        () => (req.queryParams.fromMiddleware = "1")
+      ).then(() => next());
+    };
+
+    server = new Server({
+      environment: "test",
+      routes() {
+        this.middleware = [middleware];
+        this.get("/path", (schema, req) => {
+          return req.queryParams.fromMiddleware ? "yay" : "boo";
+        });
+      },
+    });
+
+    let data = await fetch("/path").then((res) => res.text());
+    expect(data).toEqual("yay");
+  });
+
+  test("asynchronous callback AFTER calling next()", async () => {
+    const middleware = (schema, req, next) => {
+      next();
+      return asynchronousTask(() => "yay");
+    };
+
+    server = new Server({
+      environment: "test",
+      routes() {
+        this.middleware = [middleware];
+        this.get("/path", (schema, req) => {
+          return "boo";
+        });
+      },
+    });
+
+    let data = await fetch("/path").then((res) => res.text());
+    expect(data).toEqual("yay");
+  });
+});


### PR DESCRIPTION
# Add a few tests

Well, my intent was to see what it would take to add async support to the recent middleware API, so I started adding tests... and the tests already pass with **no code changes necessary.**

There's a bit of gymnastics around the `MaybePromise` responses, but I think that's to be expected at this stage in the code.