### PR TITLE
Add documentation for embed function

### DIFF
--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -324,7 +324,52 @@ class Serializer {
       }
       ```
 
-      You can also define `embed` as a function so it can be determined dynamically.
+      `embed` also accepts a function that you can use to selectively embed relationships. This is particularly useful if you need to simulate an API endpoint that embeds some relationships, but not others. For example, if our `author` model from above also had a `comment`s relationship, setting `embed: true` would embed both the `blog-post`s and `comment`s relationships:
+
+      ```
+      GET /authors/1
+
+      {
+        author: {
+          id: 1,
+          name: 'Link',
+          blogPosts: [
+            { id: 1, authorId: 1, title: 'Lorem' },
+            { id: 2, authorId: 1, title: 'Ipsum' }
+          ],
+          comments: [
+            { id: 1, authorId: 1, text: 'Dolor' },
+            { id: 2, authorId: 1, text: 'Sit' },
+          ]
+        }
+      }
+      ```
+
+      If you only want to embed `blog-post`s and instead have the `comment` IDs included, you could pass the following function to embed that only returns true for the key `blog-post`s:
+
+      ```js
+      Serializer.extend({
+        embed: (key) => key === 'blogPosts'
+      });
+      ```
+
+      Which would give us the following response:
+
+      ```
+      GET /authors/1
+
+      {
+        author: {
+          id: 1,
+          name: 'Link',
+          blogPosts: [
+            { id: 1, authorId: 1, title: 'Lorem' },
+            { id: 2, authorId: 1, title: 'Ipsum' }
+          ],
+          commentIds: [1, 2],
+        }
+      }
+      ```
     */
     this.embed = this.embed || undefined; // this is just here so I can add the doc comment. Better way?
     this._embedFn = isFunction(this.embed) ? this.embed : () => !!this.embed;


### PR DESCRIPTION
Adds documentation for passing a function to embed to selectively include relationships. Looking at the diff, I see that there's a small blurb about embed receiving a function, but it's not showing up in the docs for some reason. I also elaborated on the documentation with an example. Here's a screenshot of what the docs currently look like for the embed property (note the lack of the line that mentions embed being able to receive a function):

<img width="1509" alt="Screenshot 2023-12-15 at 2 31 17 PM" src="https://github.com/miragejs/miragejs/assets/5761147/766d2629-adfd-4450-ad1a-5d284fa16155">
