### PR TITLE
Breaking: Make createServer async to support MSW.

### DIFF
--- a/__tests__/internal/unit/server-test.js
+++ b/__tests__/internal/unit/server-test.js
@@ -43,16 +43,16 @@ describe("Unit | Server", function () {
 });
 
 describe("Unit | createServer", function () {
-  test("it returns a server instance", () => {
-    let server = createServer();
+  test("it returns a server instance", async () => {
+    let server = await createServer();
 
     expect(server).toBeTruthy();
 
     server.shutdown();
   });
 
-  test("routes return pretender handler", () => {
-    let server = createServer({ environment: "test" });
+  test("routes return pretender handler", async () => {
+    let server = await createServer({ environment: "test" });
 
     let handler = server.post("foo");
 
@@ -61,10 +61,10 @@ describe("Unit | createServer", function () {
     server.shutdown();
   });
 
-  test("it runs the default scenario in non-test environments", () => {
+  test("it runs the default scenario in non-test environments", async () => {
     expect.assertions(1);
 
-    let server = createServer({
+    let server = await createServer({
       environment: "development",
       seeds() {
         expect(true).toBeTruthy();
@@ -74,16 +74,16 @@ describe("Unit | createServer", function () {
     server.shutdown();
   });
 
-  test("forces timing to be 0 in test environment", () => {
-    let server = createServer({ environment: "test" });
+  test("forces timing to be 0 in test environment", async () => {
+    let server = await createServer({ environment: "test" });
 
     expect(server.timing).toEqual(0);
 
     server.shutdown();
   });
 
-  test("allows setting the timing to 0", () => {
-    let server = createServer({ timing: 0 });
+  test("allows setting the timing to 0", async () => {
+    let server = await createServer({ timing: 0 });
 
     expect(server.timing).toEqual(0);
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -39,8 +39,10 @@ const defaultInflector = { singularize, pluralize };
  * @param {Object} options.factories Server factories
  * @param {Object} options.pretender Pretender instance
  */
-export function createServer(options) {
-  return new Server(options);
+export async function createServer(options) {
+  const server = new Server();
+  await server.config(options);
+  return server;
 }
 
 /**
@@ -75,7 +77,6 @@ export default class Server {
    */
   constructor(options = {}) {
     this._container = new Container();
-    this.config(options);
 
     /**
       Returns the Mirage Db instance.
@@ -128,7 +129,7 @@ export default class Server {
     this.interceptor.passthroughChecks = value;
   }
 
-  config(config = {}) {
+  async config(config = {}) {
     if (!config.interceptor) {
       config.interceptor = new PretenderConfig();
     }
@@ -303,7 +304,7 @@ export default class Server {
       this.loadFixtures();
     }
 
-    this.interceptor.start?.();
+    await this.interceptor.start?.();
   }
 
   /**

--- a/lib/server.js
+++ b/lib/server.js
@@ -41,7 +41,6 @@ const defaultInflector = { singularize, pluralize };
  */
 export async function createServer(options) {
   const server = new Server(options);
-  await server.config(options);
   await server.start();
   return server;
 }

--- a/lib/server.js
+++ b/lib/server.js
@@ -40,8 +40,9 @@ const defaultInflector = { singularize, pluralize };
  * @param {Object} options.pretender Pretender instance
  */
 export async function createServer(options) {
-  const server = new Server();
+  const server = new Server(options);
   await server.config(options);
+  await server.start();
   return server;
 }
 
@@ -77,6 +78,7 @@ export default class Server {
    */
   constructor(options = {}) {
     this._container = new Container();
+    this.config(options);
 
     /**
       Returns the Mirage Db instance.
@@ -129,7 +131,7 @@ export default class Server {
     this.interceptor.passthroughChecks = value;
   }
 
-  async config(config = {}) {
+  config(config = {}) {
     if (!config.interceptor) {
       config.interceptor = new PretenderConfig();
     }
@@ -303,7 +305,18 @@ export default class Server {
     } else {
       this.loadFixtures();
     }
+  }
 
+  /**
+   * Start up the interceptor.
+   *
+   * Note: this is technically only required for msw, it is a no-op with pretender.
+   *
+   * @method start
+   * @public
+   * @hide
+   */
+  async start() {
     await this.interceptor.start?.();
   }
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -61,7 +61,16 @@ let esm = {
     babel({
       exclude: "node_modules/**",
       sourceMaps: true,
-      presets: [["@babel/preset-env", {}]],
+      presets: [
+        [
+          "@babel/preset-env",
+          {
+            targets: {
+              esmodules: true,
+            },
+          },
+        ],
+      ],
     }),
   ],
 };

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -411,7 +411,7 @@ declare module "miragejs/server" {
     Factories extends AnyFactories
   >(
     config: ServerConfig<Models, Factories>
-  ): Server<MirageRegistry<Models, Factories>>;
+  ): Promise<Server<MirageRegistry<Models, Factories>>>;
 
   export class Server<Registry extends AnyRegistry = AnyRegistry> {
     constructor(options?: ServerConfig<AnyModels, AnyFactories>);


### PR DESCRIPTION
This is to support MSW startup, which is async.  It has the downside of also making startup using pretender also async, even though it doesn't need to be.  Perhaps there's a bit of an inversion we can do here, so that the interceptors import from miragejs core, and users interact only directly with the interceptors.  I'll try experimenting around with something like that, but in the meantime, we could release this as an alpha version in case anyone wants to experiment with mirage-msw.  To that end, this PR is targeting a new `next` branch, to keep the main branch clean in case we need to release something (unlikely, I know).