### PR TITLE
Fix Response body TypeScript types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -57,13 +57,13 @@ declare module "miragejs" {
     constructor(
       code: number,
       headers?: Record<string, string>,
-      body?: string | Record<KeyType, any> | BodyInit
+      body?: string | Record<keyof any, any> | BodyInit
     );
 
     toRackResponse(): [
       number,
       Record<string, string> | undefined,
-      string | Record<KeyType, any> | BodyInit | undefined,
+      string | Record<keyof any, any> | BodyInit | undefined,
     ];
   }
 


### PR DESCRIPTION
Ugh, this is what we get for writing the types separately.  `KeyType` is not what I thought it was.  We just want the set of all valid key types, which can be strings or numbers or symbols.  The fix I've made here is basically how TypeScript itself does it, so it should be correct now.