### PR TITLE
Breaking: Separate async `start` from `createServer`

### DIFF
--- a/__tests__/external/browser-only/passthrough-test.js
+++ b/__tests__/external/browser-only/passthrough-test.js
@@ -151,7 +151,7 @@ describe("External | Browser only | Passthrough", () => {
     await expect(fetch("http://api.foo.bar/addresses")).rejects.toThrow(
       "Network request failed"
     );
-  });
+  }, 8000); // slightly longer timeout, this one seems to have trouble sometimes
 
   test("it can take a function", async () => {
     server.config({

--- a/__tests__/internal/unit/server-test.js
+++ b/__tests__/internal/unit/server-test.js
@@ -44,7 +44,7 @@ describe("Unit | Server", function () {
 
 describe("Unit | createServer", function () {
   test("it returns a server instance", async () => {
-    let server = await createServer();
+    let server = createServer();
 
     expect(server).toBeTruthy();
 
@@ -52,7 +52,7 @@ describe("Unit | createServer", function () {
   });
 
   test("routes return pretender handler", async () => {
-    let server = await createServer({ environment: "test" });
+    let server = createServer({ environment: "test" });
 
     let handler = server.post("foo");
 
@@ -64,7 +64,7 @@ describe("Unit | createServer", function () {
   test("it runs the default scenario in non-test environments", async () => {
     expect.assertions(1);
 
-    let server = await createServer({
+    let server = createServer({
       environment: "development",
       seeds() {
         expect(true).toBeTruthy();
@@ -75,7 +75,7 @@ describe("Unit | createServer", function () {
   });
 
   test("forces timing to be 0 in test environment", async () => {
-    let server = await createServer({ environment: "test" });
+    let server = createServer({ environment: "test" });
 
     expect(server.timing).toBe(0);
 
@@ -83,7 +83,7 @@ describe("Unit | createServer", function () {
   });
 
   test("allows setting the timing to 0", async () => {
-    let server = await createServer({ timing: 0 });
+    let server = createServer({ timing: 0 });
 
     expect(server.timing).toBe(0);
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -39,9 +39,8 @@ const defaultInflector = { singularize, pluralize };
  * @param {Object} options.factories Server factories
  * @param {Object} options.pretender Pretender instance
  */
-export async function createServer(options) {
+export function createServer(options) {
   const server = new Server(options);
-  await server.start();
   return server;
 }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -411,10 +411,12 @@ declare module "miragejs/server" {
     Factories extends AnyFactories,
   >(
     config: ServerConfig<Models, Factories>
-  ): Promise<Server<MirageRegistry<Models, Factories>>>;
+  ): Server<MirageRegistry<Models, Factories>>;
 
   export class Server<Registry extends AnyRegistry = AnyRegistry> {
     constructor(options?: ServerConfig<AnyModels, AnyFactories>);
+
+    start(): Promise<void>;
 
     /** The underlying in-memory database instance for this server. */
     readonly db: Db;


### PR DESCRIPTION
This will allow pretender users to call `createServer()` synchronously as before, while still giving msw users a way to await server startup:

```diff
import MSWInterceptor from 'mirage-msw';
import { createServer } from 'miragejs';

- await createServer({
+ const server = createServer({
  interceptor: new MSWInterceptor(),
  // ... rest of your config
});

+ await server.start();
```