### PR TITLE
fix: Use `logging` from config

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -250,7 +250,7 @@ export default class Server {
       @return {Boolean}
       @public
     */
-    this.logging = config.logging !== undefined ? config.logging : undefined;
+    this.logging = config.logging || undefined;
 
     this.testConfig = this.testConfig || undefined;
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -250,7 +250,7 @@ export default class Server {
       @return {Boolean}
       @public
     */
-    this.logging = config.logging !== undefined ? this.logging : undefined;
+    this.logging = config.logging !== undefined ? config.logging : undefined;
 
     this.testConfig = this.testConfig || undefined;
 


### PR DESCRIPTION
Currently when setting up the config, we're looking at if config.logging is undefined - if it's not, we're using this.logging. This means that whatever value you pass in as config.logging will be ignored.