### PR TITLE
fix: prevent using reserved words while defining models in miragejs

### DIFF
--- a/lib/orm/model.js
+++ b/lib/orm/model.js
@@ -65,29 +65,44 @@ class Model {
     assert(modelName, "A model requires a modelName");
 
     assert(
-      !this.modelName,
+      !!this.modelName,
       "The 'modelName' property is reserved by Mirage for internal use. Avoid using this property in your model to prevent conflicts."
     );
     assert(
-      !this._schema,
+      !!this._schema,
       "The '_schema' property is reserved by Mirage for internal use. Avoid using this property in your model to prevent conflicts."
     );
     assert(
-      !this.fks,
+      !!this.fks,
       "The 'fks' property is reserved by Mirage for internal use. Avoid using this property in your model to prevent conflicts."
     );
     assert(
-      !this.attrs,
+      !!this.attrs,
       "The 'attrs' property is reserved by Mirage for internal use. Avoid using this property in your model to prevent conflicts."
     );
     assert(
-      !this._tempAssociations,
+      !!this._tempAssociations,
       "The '_tempAssociations' property is reserved by Mirage for internal use. Avoid using this property in your model to prevent conflicts."
     );
     assert(
-      !this.__isSavingNewChildren,
+      !!this.__isSavingNewChildren,
       "The '__isSavingNewChildren' property is reserved by Mirage for internal use. Avoid using this property in your model to prevent conflicts."
     );
+
+    // if any of attrs keys is one of the above reject also
+    Object.keys(attrs).forEach((key) => {
+      assert(
+        ![
+          "modelName",
+          "_schema",
+          "fks",
+          "attrs",
+          "_tempAssociations",
+          "__isSavingNewChildren",
+        ].includes(key),
+        `The '${key}' property is reserved by Mirage for internal use. Avoid using this property in your model to prevent conflicts.`
+      );
+    });
 
     this._schema = schema;
     this.modelName = modelName;

--- a/lib/orm/model.js
+++ b/lib/orm/model.js
@@ -64,6 +64,31 @@ class Model {
     assert(schema, "A model requires a schema");
     assert(modelName, "A model requires a modelName");
 
+    assert(
+      !this.modelName,
+      "The 'modelName' property is reserved by Mirage for internal use. Avoid using this property in your model to prevent conflicts."
+    );
+    assert(
+      !this._schema,
+      "The '_schema' property is reserved by Mirage for internal use. Avoid using this property in your model to prevent conflicts."
+    );
+    assert(
+      !this.fks,
+      "The 'fks' property is reserved by Mirage for internal use. Avoid using this property in your model to prevent conflicts."
+    );
+    assert(
+      !this.attrs,
+      "The 'attrs' property is reserved by Mirage for internal use. Avoid using this property in your model to prevent conflicts."
+    );
+    assert(
+      !this._tempAssociations,
+      "The '_tempAssociations' property is reserved by Mirage for internal use. Avoid using this property in your model to prevent conflicts."
+    );
+    assert(
+      !this.__isSavingNewChildren,
+      "The '__isSavingNewChildren' property is reserved by Mirage for internal use. Avoid using this property in your model to prevent conflicts."
+    );
+
     this._schema = schema;
     this.modelName = modelName;
     this.fks = fks || [];

--- a/lib/orm/model.js
+++ b/lib/orm/model.js
@@ -64,31 +64,6 @@ class Model {
     assert(schema, "A model requires a schema");
     assert(modelName, "A model requires a modelName");
 
-    assert(
-      !!this.modelName,
-      "The 'modelName' property is reserved by Mirage for internal use. Avoid using this property in your model to prevent conflicts."
-    );
-    assert(
-      !!this._schema,
-      "The '_schema' property is reserved by Mirage for internal use. Avoid using this property in your model to prevent conflicts."
-    );
-    assert(
-      !!this.fks,
-      "The 'fks' property is reserved by Mirage for internal use. Avoid using this property in your model to prevent conflicts."
-    );
-    assert(
-      !!this.attrs,
-      "The 'attrs' property is reserved by Mirage for internal use. Avoid using this property in your model to prevent conflicts."
-    );
-    assert(
-      !!this._tempAssociations,
-      "The '_tempAssociations' property is reserved by Mirage for internal use. Avoid using this property in your model to prevent conflicts."
-    );
-    assert(
-      !!this.__isSavingNewChildren,
-      "The '__isSavingNewChildren' property is reserved by Mirage for internal use. Avoid using this property in your model to prevent conflicts."
-    );
-
     // if any of attrs keys is one of the above reject also
     Object.keys(attrs).forEach((key) => {
       assert(


### PR DESCRIPTION
Resolving: #1113 

This PR introduces a series of assertions to prevent potential conflicts when defining models in Mirage. Specifically, it ensures that developers do not define properties with names that are reserved for internal use by the Mirage framework. The following properties are reserved and now protected through assertions: modelName, _schema, fks, attrs, _tempAssociations, and __isSavingNewChildren.

The assertions check whether any of these reserved property names are being used in the model definition. If a reserved name is detected, an error message will be thrown, providing clear feedback to the developer about the conflict and recommending they choose a different property name.

Additionally, when creating a model, the code also validates against the attributes (attrs) provided to ensure none of their keys conflict with the reserved properties. This safeguard helps maintain the integrity of internal Mirage functionality and avoids unexpected behavior.