### PR TITLE
fix: recreating a new model with same id after getting deleted is not possible due to id already used.

### DIFF
--- a/__tests__/external/shared/orm/destroy-test.js
+++ b/__tests__/external/shared/orm/destroy-test.js
@@ -34,6 +34,20 @@ describe("External | Shared | ORM | destroy", () => {
     expect(server.db.users).toHaveLength(2);
   });
 
+  test("destroying a model marks id as unused and allows creating a new model with same id", () => {
+    expect(server.db.users).toHaveLength(3);
+
+    let link = server.schema.users.find(1);
+    link.destroy();
+
+    server.schema.users.create({ id: 1, name: "Ganon", evil: true });
+    const ganon = server.schema.users.find(1);
+
+    expect(ganon).not.toBeNull();
+    expect(ganon?.name).toBe("Ganon");
+    expect(server.db.users).toHaveLength(3);
+  });
+
   test("destroying a collection removes the associated records from the db", () => {
     expect(server.db.users).toHaveLength(3);
 

--- a/__tests__/internal/unit/db/identity-manager-test.js
+++ b/__tests__/internal/unit/db/identity-manager-test.js
@@ -82,4 +82,13 @@ describe("Unit | Db | IdentityManager", function () {
 
     expect(true).toBeTruthy();
   });
+
+  test(`unset removes id from used ids`, () => {
+    let manager = new IdentityManager();
+    manager.set("abc");
+    manager.unset("abc");
+    manager.set("abc");
+
+    expect(true).toBeTruthy();
+  });
 });

--- a/lib/db-collection.js
+++ b/lib/db-collection.js
@@ -313,17 +313,20 @@ class DbCollection {
       let record = this._findRecord(target);
       let index = this._records.indexOf(record);
       this._records.splice(index, 1);
+      this.identityManager.unset(target);
     } else if (Array.isArray(target)) {
       records = this._findRecords(target);
       records.forEach((record) => {
         let index = this._records.indexOf(record);
         this._records.splice(index, 1);
+        this.identityManager.unset(target);
       });
     } else if (typeof target === "object") {
       records = this._findRecordsWhere(target);
       records.forEach((record) => {
         let index = this._records.indexOf(record);
         this._records.splice(index, 1);
+        this.identityManager.unset(target);
       });
     }
   }

--- a/lib/identity-manager.js
+++ b/lib/identity-manager.js
@@ -58,6 +58,21 @@ class IdentityManager {
   }
 
   /**
+    Marks `uniqueIdentifier` as unused.
+
+    @method unset
+    @param {String|Number} uniqueIdentifier
+    @public
+  */
+  unset(uniqueIdentifier) {
+    if (!this._ids[uniqueIdentifier]) {
+      return;
+    }
+
+    this._ids[uniqueIdentifier] = false;
+  }
+
+  /**
     @method inc
     @hide
     @private


### PR DESCRIPTION
How to reproduce:

* `server.create('user', { id: 1 });`
* `server.schema.users.find(1).destroy();`
* `server.create('user', { id: 1 });`
===
`Attempting to use the ID 1, but it's already been used`

I left the nextId untouched, because it would only make sense to reset from, lets say, 10 to 9 if the last element gets removed, but not, if 9 gets removed but we already have 15 models. And to reset for this only case is not worth to implement and maintain, in my opinion.