### PR TITLE
Fix type definitions tests

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,7 +7,7 @@
 /tmp
 **/.gitkeep
 /__tests__/
-/tests/
+/types/tests/
 /yarn.lock
 .gitkeep
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "build": "rimraf dist && rollup -c",
     "prepublishOnly": "yarn run build",
     "test:run": "node --experimental-vm-modules $(yarn bin jest)",
-    "test": "run-s build test:run",
+    "test:types": "tsd -f 'tests/*.ts' -t index.d.ts types",
+    "test": "run-s build test:types test:run",
     "ci": "run-s lint prettier:check test"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -76,8 +76,7 @@
     "prettier": "3.3.2",
     "rimraf": "^5.0.7",
     "rollup": "^4.18.0",
-    "tslint": "^6.1.3",
-    "tslint-config-prettier": "^1.18.0",
+    "tsd": "^0.32.0",
     "typescript": "^5.4.5"
   },
   "packageManager": "yarn@4.3.0+sha512.1606bef7c84bc7d83b8576063de2fd08f7d69f9939015bed800f9585a002390268ecc777e9feeba7e26e9556aef6beaad4806968db2182ab5dd3e955ab3b9a0b"

--- a/types/tests/collection-test.ts
+++ b/types/tests/collection-test.ts
@@ -1,4 +1,4 @@
-import {expectType, expectError} from 'tsd';
+import { expectType, expectError } from "tsd";
 import { Collection } from "miragejs";
 
 type ModelType = { name: string };
@@ -10,13 +10,17 @@ expectError(collection.add({ err: "err" }));
 
 expectType<Collection<ModelType>>(collection.destroy());
 
-expectType<Collection<ModelType>>(collection.filter((item) => item.name === "Bob"));
+expectType<Collection<ModelType>>(
+  collection.filter((item) => item.name === "Bob")
+);
 expectError(collection.filter((item) => item.err === "Err"));
 
 expectType<boolean>(collection.includes({ name: "Bob" }));
 expectError(collection.includes({ err: "err" }));
 
-expectType<Collection<ModelType>>(collection.mergeCollection(new Collection<ModelType>()));
+expectType<Collection<ModelType>>(
+  collection.mergeCollection(new Collection<ModelType>())
+);
 expectError(collection.mergeCollection(new Collection<{ err: string }>()));
 
 expectType<Collection<ModelType>>(collection.reload());
@@ -28,12 +32,16 @@ expectType<Collection<ModelType>>(collection.save());
 
 expectType<Collection<ModelType>>(collection.slice(0, 1));
 
-expectType<Collection<ModelType>>(collection.sort((a, b) => {
-  return a.name.localeCompare(b.name);
-}));
-expectError(collection.sort((a, b) => {
-  return a.err.localeCompare(b.err);
-}));
+expectType<Collection<ModelType>>(
+  collection.sort((a, b) => {
+    return a.name.localeCompare(b.name);
+  })
+);
+expectError(
+  collection.sort((a, b) => {
+    return a.err.localeCompare(b.err);
+  })
+);
 
 expectType<Collection<ModelType>>(collection.update("name", "John"));
 expectError(collection.update("name", new Date()));

--- a/types/tests/collection-test.ts
+++ b/types/tests/collection-test.ts
@@ -1,40 +1,40 @@
+import {expectType, expectError} from 'tsd';
 import { Collection } from "miragejs";
 
 type ModelType = { name: string };
 
 const collection = new Collection<ModelType>();
 
-collection.add({ name: "Bob" }); // $ExpectType Collection<ModelType>
-collection.add({ err: "err" }); // $ExpectError
+expectType<Collection<ModelType>>(collection.add({ name: "Bob" }));
+expectError(collection.add({ err: "err" }));
 
-collection.destroy(); // $ExpectType Collection<ModelType>
+expectType<Collection<ModelType>>(collection.destroy());
 
-collection.filter((item) => item.name === "Bob"); // $ExpectType Collection<ModelType>
-collection.filter((item) => item.err === "Err"); // $ExpectError
+expectType<Collection<ModelType>>(collection.filter((item) => item.name === "Bob"));
+expectError(collection.filter((item) => item.err === "Err"));
 
-collection.includes({ name: "Bob" }); // $ExpectType boolean
-collection.includes({ err: "err" }); // $ExpectError
+expectType<boolean>(collection.includes({ name: "Bob" }));
+expectError(collection.includes({ err: "err" }));
 
-collection.mergeCollection(new Collection<ModelType>()); // $ExpectType Collection<ModelType>
-collection.mergeCollection(new Collection<{ err: string }>()); // $ExpectError
+expectType<Collection<ModelType>>(collection.mergeCollection(new Collection<ModelType>()));
+expectError(collection.mergeCollection(new Collection<{ err: string }>()));
 
-collection.reload(); // $ExpectType Collection<ModelType>
+expectType<Collection<ModelType>>(collection.reload());
 
-collection.remove({ name: "Bob" }); // $ExpectType Collection<ModelType>
-collection.remove({ err: "Err" }); // $ExpectError
+expectType<Collection<ModelType>>(collection.remove({ name: "Bob" }));
+expectError(collection.remove({ err: "Err" }));
 
-collection.save(); // $ExpectType Collection<ModelType>
+expectType<Collection<ModelType>>(collection.save());
 
-collection.slice(0, 1); // $ExpectType Collection<ModelType>
+expectType<Collection<ModelType>>(collection.slice(0, 1));
 
-// $ExpectType Collection<ModelType>
-collection.sort((a, b) => {
+expectType<Collection<ModelType>>(collection.sort((a, b) => {
   return a.name.localeCompare(b.name);
-});
-collection.sort((a, b) => {
-  return a.err.localeCompare(b.err); // $ExpectError
-});
+}));
+expectError(collection.sort((a, b) => {
+  return a.err.localeCompare(b.err);
+}));
 
-collection.update("name", "John"); // $ExpectType Collection<ModelType>
-collection.update("name", new Date()); // $ExpectError
-collection.update("err", "err"); // $ExpectError
+expectType<Collection<ModelType>>(collection.update("name", "John"));
+expectError(collection.update("name", new Date()));
+expectError(collection.update("err", "err"));

--- a/types/tests/db-test.ts
+++ b/types/tests/db-test.ts
@@ -1,9 +1,9 @@
-import {expectType, expectError} from 'tsd';
+import { expectType, expectError } from "tsd";
 import DbCollection from "miragejs/db-collection";
 import { Server } from "miragejs/server";
 import { Registry } from "miragejs";
 import { ModelDefinition } from "miragejs/-types";
-import Db from 'miragejs/db';
+import Db from "miragejs/db";
 
 const server: Server = new Server();
 

--- a/types/tests/db-test.ts
+++ b/types/tests/db-test.ts
@@ -1,7 +1,9 @@
+import {expectType, expectError} from 'tsd';
 import DbCollection from "miragejs/db-collection";
 import { Server } from "miragejs/server";
 import { Registry } from "miragejs";
 import { ModelDefinition } from "miragejs/-types";
+import Db from 'miragejs/db';
 
 const server: Server = new Server();
 
@@ -13,32 +15,33 @@ server.db.loadData({
   ],
 });
 
-const myDb = server.db; // $ExpectType Db
+const myDb = server.db;
+expectType<Db>(myDb);
 
 interface Movie {
   title: string;
 }
 
-myDb.createCollection("movies", [{ title: "Interstellar" }]); // $ExpectType void
-myDb.dump(); // $ExpectType void
-myDb.emptyData(); // $ExpectType void
-myDb.loadData({}); // $ExpectType void
+expectType<void>(myDb.createCollection("movies", [{ title: "Interstellar" }]));
+expectType<void>(myDb.dump());
+expectType<void>(myDb.emptyData());
+expectType<void>(myDb.loadData({}));
 
 const dbCollection = new DbCollection("movies", [{ title: "Dunkirk" }]);
 
-myDb.users.find(1); // $ExpectType any
-myDb.users.find([1, 2]); // $ExpectType any
-myDb.users.findBy({ name: "Link" }); // $ExpectType any
-myDb.users.where({ name: "Link" }); // $ExpectType any
-myDb.users.insert({}); // $ExpectType any
-myDb.users.insert([]); // $ExpectType any
-myDb.users.firstOrCreate({ name: "Link" }); // $ExpectType any
-myDb.users.remove(); // $ExpectType void
-myDb.users.remove(1); // $ExpectType void
-myDb.users.remove({ name: "Zelda" }); // $ExpectType void
-myDb.users.update({ name: "Ganon" }); // $ExpectType any
-myDb.users.update(1, { name: "Young Link" }); // $ExpectType any
-myDb.users.update({ name: "Link" }, { name: "Epona" }); // $ExpectType any
+expectType<any>(myDb.users.find(1));
+expectType<any>(myDb.users.find([1, 2]));
+expectType<any>(myDb.users.findBy({ name: "Link" }));
+expectType<any>(myDb.users.where({ name: "Link" }));
+expectType<any>(myDb.users.insert({}));
+expectType<any>(myDb.users.insert([]));
+expectType<any>(myDb.users.firstOrCreate({ name: "Link" }));
+expectType<void>(myDb.users.remove());
+expectType<void>(myDb.users.remove(1));
+expectType<void>(myDb.users.remove({ name: "Zelda" }));
+expectType<any>(myDb.users.update({ name: "Ganon" }));
+expectType<any>(myDb.users.update(1, { name: "Young Link" }));
+expectType<any>(myDb.users.update({ name: "Link" }, { name: "Epona" }));
 
 type TestModels = {
   movie: ModelDefinition<Movie>;

--- a/types/tests/factory-test.ts
+++ b/types/tests/factory-test.ts
@@ -1,3 +1,4 @@
+import {expectType, expectError} from 'tsd';
 import { Factory, Model, Registry } from "miragejs";
 import Schema from "miragejs/orm/schema";
 
@@ -46,43 +47,43 @@ declare const schema: Schema<
 {
   const people = schema.all("personExplicit");
 
-  people.length; // $ExpectType number
-  people.modelName; // $ExpectType string
+  expectType<number>(people.length);
+  expectType<string>(people.modelName);
   people.models.map((model) => {
-    model.id; // $ExpectType string | undefined
-    model.name; // $ExpectType string
-    model.attrs; // $ExpectType { name: string; age?: number | undefined; height?: string | undefined; }
-    model.age; // $ExpectType number | undefined
-    model.height; // $ExpectType string | undefined
-    model.foo; // $ExpectError
+    expectType<string | undefined>(model.id);
+    expectType<string>(model.name);
+    expectType<{ name: string; age?: number | undefined; height?: string | undefined; }>(model.attrs);
+    expectType<number | undefined>(model.age);
+    expectType<string | undefined>(model.height);
+    expectError(model.foo);
   });
 
-  schema.create("personExplicit").height; // $ExpectType string
-  schema.create("personExplicit", {}).height; // $ExpectType string | undefined
-  schema.create("personExplicit", { height: "custom" }).height; // $ExpectType string
+  expectType<string>(schema.create("personExplicit").height);
+  expectType<string | undefined>(schema.create("personExplicit", {}).height);
+  expectType<string>(schema.create("personExplicit", { height: "custom" }).height);
 
-  schema.create("personExplicit", { height: 123 }); // $ExpectError
-  schema.create("personExplicit", { foo: "bar" }); // $ExpectError
+  expectError(schema.create("personExplicit", { height: 123 }));
+  expectError(schema.create("personExplicit", { foo: "bar" }));
 }
 
 {
   const people = schema.all("personInferred");
 
-  people.length; // $ExpectType number
-  people.modelName; // $ExpectType string
+  expectType<number>(people.length);
+  expectType<string>(people.modelName);
   people.models.map((model) => {
-    model.id; // $ExpectType string | undefined
-    model.name; // $ExpectType string
-    model.attrs; // $ExpectType { name: string; age: number; height: string; }
-    model.age; // $ExpectType number
-    model.height; // $ExpectType string
-    model.foo; // $ExpectError
+    expectType<string | undefined>(model.id);
+    expectType<string>(model.name);
+    expectType<{ name: string; age: number; height: string; }>(model.attrs);
+    expectType<number>(model.age);
+    expectType<string>(model.height);
+    expectError(model.foo);
   });
 
-  schema.create("personInferred").height; // $ExpectType string
-  schema.create("personInferred", {}).height; // $ExpectType string
-  schema.create("personInferred", { height: "custom" }).height; // $ExpectType string
+  expectType<string>(schema.create("personInferred").height);
+  expectType<string>(schema.create("personInferred", {}).height);
+  expectType<string>(schema.create("personInferred", { height: "custom" }).height);
 
-  schema.create("personInferred", { height: 123 }); // $ExpectError
-  schema.create("personInferred", { foo: "bar" }); // $ExpectError
+  expectError(schema.create("personInferred", { height: 123 }));
+  expectError(schema.create("personInferred", { foo: "bar" }));
 }

--- a/types/tests/factory-test.ts
+++ b/types/tests/factory-test.ts
@@ -1,4 +1,4 @@
-import {expectType, expectError} from 'tsd';
+import { expectType, expectError } from "tsd";
 import { Factory, Model, Registry } from "miragejs";
 import Schema from "miragejs/orm/schema";
 
@@ -52,7 +52,11 @@ declare const schema: Schema<
   people.models.map((model) => {
     expectType<string | undefined>(model.id);
     expectType<string>(model.name);
-    expectType<{ name: string; age?: number | undefined; height?: string | undefined; }>(model.attrs);
+    expectType<{
+      name: string;
+      age?: number | undefined;
+      height?: string | undefined;
+    }>(model.attrs);
     expectType<number | undefined>(model.age);
     expectType<string | undefined>(model.height);
     expectError(model.foo);
@@ -60,7 +64,9 @@ declare const schema: Schema<
 
   expectType<string>(schema.create("personExplicit").height);
   expectType<string | undefined>(schema.create("personExplicit", {}).height);
-  expectType<string>(schema.create("personExplicit", { height: "custom" }).height);
+  expectType<string>(
+    schema.create("personExplicit", { height: "custom" }).height
+  );
 
   expectError(schema.create("personExplicit", { height: 123 }));
   expectError(schema.create("personExplicit", { foo: "bar" }));
@@ -74,7 +80,7 @@ declare const schema: Schema<
   people.models.map((model) => {
     expectType<string | undefined>(model.id);
     expectType<string>(model.name);
-    expectType<{ name: string; age: number; height: string; }>(model.attrs);
+    expectType<{ name: string; age: number; height: string }>(model.attrs);
     expectType<number>(model.age);
     expectType<string>(model.height);
     expectError(model.foo);
@@ -82,7 +88,9 @@ declare const schema: Schema<
 
   expectType<string>(schema.create("personInferred").height);
   expectType<string>(schema.create("personInferred", {}).height);
-  expectType<string>(schema.create("personInferred", { height: "custom" }).height);
+  expectType<string>(
+    schema.create("personInferred", { height: "custom" }).height
+  );
 
   expectError(schema.create("personInferred", { height: 123 }));
   expectError(schema.create("personInferred", { foo: "bar" }));

--- a/types/tests/identity-manager-test.ts
+++ b/types/tests/identity-manager-test.ts
@@ -1,12 +1,13 @@
+import {expectType, expectError} from 'tsd';
 import { createServer, IdentityManager, Model } from "miragejs";
 
 const identityManager = new IdentityManager();
 
-identityManager.get?.(); // $ExpectType number | undefined
-identityManager.set("id"); // $ExpectType void
-identityManager.inc?.(); // $ExpectType number | undefined
-identityManager.fetch(); // $ExpectType string
-identityManager.reset(); // $ExpectType void
+expectType<number|undefined>(identityManager.get?.());
+expectType<void>(identityManager.set("id"));
+expectType<number|undefined>(identityManager.inc?.());
+expectType<string>(identityManager.fetch());
+expectType<void>(identityManager.reset());
 
 createServer({
   identityManagers: {
@@ -14,12 +15,12 @@ createServer({
   },
 });
 
-createServer({
+expectError(createServer({
   models: {
     pet: Model.extend({}),
   },
   identityManagers: {
     pet: IdentityManager,
-    foo: IdentityManager, // $ExpectError
+    foo: IdentityManager,
   },
-});
+}));

--- a/types/tests/identity-manager-test.ts
+++ b/types/tests/identity-manager-test.ts
@@ -1,11 +1,11 @@
-import {expectType, expectError} from 'tsd';
+import { expectType, expectError } from "tsd";
 import { createServer, IdentityManager, Model } from "miragejs";
 
 const identityManager = new IdentityManager();
 
-expectType<number|undefined>(identityManager.get?.());
+expectType<number | undefined>(identityManager.get?.());
 expectType<void>(identityManager.set("id"));
-expectType<number|undefined>(identityManager.inc?.());
+expectType<number | undefined>(identityManager.inc?.());
 expectType<string>(identityManager.fetch());
 expectType<void>(identityManager.reset());
 
@@ -15,12 +15,14 @@ createServer({
   },
 });
 
-expectError(createServer({
-  models: {
-    pet: Model.extend({}),
-  },
-  identityManagers: {
-    pet: IdentityManager,
-    foo: IdentityManager,
-  },
-}));
+expectError(
+  createServer({
+    models: {
+      pet: Model.extend({}),
+    },
+    identityManagers: {
+      pet: IdentityManager,
+      foo: IdentityManager,
+    },
+  })
+);

--- a/types/tests/model-test.ts
+++ b/types/tests/model-test.ts
@@ -1,3 +1,4 @@
+import {expectType, expectError} from 'tsd';
 import { Model, Registry } from "miragejs";
 import Schema from "miragejs/orm/schema";
 
@@ -9,27 +10,27 @@ declare const schema: Schema<Registry<{ person: typeof PersonModel }, {}>>;
 
 const people = schema.all("person");
 
-people.length; // $ExpectType number
-people.modelName; // $ExpectType string
+expectType<number>(people.length);
+expectType<string>(people.modelName);
 people.models.map((model) => {
-  model.id; // $ExpectType string | undefined
-  model.name; // $ExpectType string
-  model.modelName; // $ExpectType string
-  model.attrs; // $ExpectType { name: string; }
-  model.foo; // $ExpectError
+  expectType<string|undefined>(model.id);
+  expectType<string>(model.name);
+  expectType<string>(model.modelName);
+  expectType<{name: string}>(model.attrs);
+  expectError(model.foo);
 
-  model.save(); // $ExpectType void
-  model.reload(); // $ExpectType void
-  model.destroy(); // $ExpectType void
+  expectType<void>(model.save());
+  expectType<void>(model.reload());
+  expectType<void>(model.destroy());
 
-  model.update("name", "goodbye"); // $ExpectType void
-  model.update("name", false); // $ExpectError
-  model.update("bad", "ok"); // $ExpectError
+  expectType<void>(model.update("name", "goodbye"));
+  expectError(model.update("name", false));
+  expectError(model.update("bad", "ok"));
 });
 
-schema.create("person").name; // $ExpectType string
-schema.create("person", {}).name; // $ExpectType string
-schema.create("person", { name: "custom" }).name; // $ExpectType string
+expectType<string>(schema.create("person").name);
+expectType<string>(schema.create("person", {}).name);
+expectType<string>(schema.create("person", { name: "custom" }).name);
 
-schema.create("person", { name: 123 }); // $ExpectError
-schema.create("person", { foo: "bar" }); // $ExpectError
+expectError(schema.create("person", { name: 123 }));
+expectError(schema.create("person", { foo: "bar" }));

--- a/types/tests/model-test.ts
+++ b/types/tests/model-test.ts
@@ -1,4 +1,4 @@
-import {expectType, expectError} from 'tsd';
+import { expectType, expectError } from "tsd";
 import { Model, Registry } from "miragejs";
 import Schema from "miragejs/orm/schema";
 
@@ -13,10 +13,10 @@ const people = schema.all("person");
 expectType<number>(people.length);
 expectType<string>(people.modelName);
 people.models.map((model) => {
-  expectType<string|undefined>(model.id);
+  expectType<string | undefined>(model.id);
   expectType<string>(model.name);
   expectType<string>(model.modelName);
-  expectType<{name: string}>(model.attrs);
+  expectType<{ name: string }>(model.attrs);
   expectError(model.foo);
 
   expectType<void>(model.save());

--- a/types/tests/relationships-test.ts
+++ b/types/tests/relationships-test.ts
@@ -1,3 +1,4 @@
+import {expectType, expectError} from 'tsd';
 import {
   belongsTo,
   Collection,
@@ -32,32 +33,32 @@ declare const schema: Schema<PersonRegistry>;
 
 const people = schema.all("person");
 
-people.length; // $ExpectType number
-people.modelName; // $ExpectType string
+expectType<number>(people.length);
+expectType<string>(people.modelName);
 people.models.map((model) => {
-  model.nothing; // $ExpectType unknown
-  model.muchAdoAboutNothing; // $ExpectType Collection<unknown>
+  expectType<unknown>(model.nothing);
+  expectType<Collection<unknown>>(model.muchAdoAboutNothing);
 
-  model.parent?.name; // $ExpectType string | undefined
-  model.parent?.parent?.name; // $ExpectType string | undefined
-  model.pets.models[0].name; // $ExpectType string
+  expectType<string | undefined>(model.parent?.name);
+  expectType<string | undefined>(model.parent?.parent?.name);
+  expectType<string>(model.pets.models[0].name);
 
   // Polymorphic relationship
   const friend = model.friends.models[0];
 
   // Both 'pet' and 'person' models have a name, but no other shared fields
-  friend.name; // $ExpectType string
-  friend.parent; // $ExpectError
-  friend.friends; // $ExpectError
-  friend.owner; // $ExpectError
+  expectType<string>(friend.name);
+  expectError(friend.parent);
+  expectError(friend.friends);
+  expectError(friend.owner);
 
   if ("parent" in friend) {
     // Here we know friend is a person
-    friend.parent!.name; // $ExpectType string
-    friend.friends.length; // $ExpectType number
+    expectType<string>(friend.parent!.name);
+    expectType<number>(friend.friends.length);
   } else {
     // Here we know friend is a pet
-    friend.owner!.name; // $ExpectType string
+    expectType<string>(friend.owner!.name);
   }
 });
 
@@ -66,9 +67,9 @@ const child = schema.create("person", {
 });
 
 // Here we know `parent` is defined because it was just passed in
-child.parent.name; // $ExpectType string
+expectType<string>(child.parent.name);
 
-schema.create("person", { parent: "hi" }); // $ExpectError
+expectError(schema.create("person", { parent: "hi" }));
 
 const pet1 = schema.create("pet");
 const pet2 = schema.create("pet");
@@ -89,13 +90,13 @@ personWithPetsArray.update(
   new Collection<Instantiate<PersonRegistry, "pet">>()
 );
 
-personWithPetsArray.pets.modelName; // $ExpectType string
+expectType<string>(personWithPetsArray.pets.modelName);
 
 const personWithPetsCollection = schema.create("person", {
   pets: schema.all("pet"),
 });
 
-personWithPetsCollection.pets.modelName; // $ExpectType string
+expectType<string>(personWithPetsCollection.pets.modelName);
 
-schema.create("person", { pets: [child] }); // $ExpectError
-schema.create("person", { pets: schema.all("person") }); // $ExpectError
+expectError(schema.create("person", { pets: [child] }));
+expectError(schema.create("person", { pets: schema.all("person") }));

--- a/types/tests/relationships-test.ts
+++ b/types/tests/relationships-test.ts
@@ -1,4 +1,4 @@
-import {expectType, expectError} from 'tsd';
+import { expectType, expectError } from "tsd";
 import {
   belongsTo,
   Collection,

--- a/types/tests/schema-test.ts
+++ b/types/tests/schema-test.ts
@@ -1,3 +1,4 @@
+import {expectType, expectError} from 'tsd';
 import { Factory, Model, Registry } from "miragejs";
 import Schema from "miragejs/orm/schema";
 
@@ -13,31 +14,31 @@ declare const schema: Schema<
   Registry<{ foo: typeof FooModel }, { foo: typeof FooFactory }>
 >;
 
-schema.create("foo").attr; // $ExpectType string
-schema.create("foo", { attr: "ok" }).attr; // $ExpectType string
-schema.create("foo", { attr: 123 }); // $ExpectError
-schema.create("foo", { x: true }); // $ExpectError
-schema.create("cow"); // $ExpectError
+expectType<string>(schema.create("foo").attr);
+expectType<string>(schema.create("foo", { attr: "ok" }).attr);
+expectError(schema.create("foo", { attr: 123 }));
+expectError(schema.create("foo", { x: true }));
+expectError(schema.create("cow"));
 
-schema.find("foo", "123")?.attr; // $ExpectType string | undefined
-schema.find("foo", ["123"]).models[0].attr; // $ExpectType string
-schema.find("cow", "123"); // $ExpectError
+expectType<string | undefined>(schema.find("foo", "123")?.attr);
+expectType<string>(schema.find("foo", ["123"]).models[0].attr);
+expectError(schema.find("cow", "123"));
 
-schema.findOrCreateBy("foo", { attr: "hi" }).attr; // $ExpectType string
-schema.findOrCreateBy("foo", { bar: true }); // $ExpectError
-schema.findOrCreateBy("cow", { attr: "bar" }); // $ExpectError
+expectType<string>(schema.findOrCreateBy("foo", { attr: "hi" }).attr);
+expectError(schema.findOrCreateBy("foo", { bar: true }));
+expectError(schema.findOrCreateBy("cow", { attr: "bar" }));
 
-schema.where("foo", { attr: "bar" }).models[0].attr; // $ExpectType string
-schema.where("foo", { bar: true }); // $ExpectError
-schema.where("foo", (foo) => foo.attr === "ok").models[0].attr; // $ExpectType string
-schema.where("foo", (foo) => foo.x === "ok"); // $ExpectError
-schema.where("cow", { attr: "bar" }); // $ExpectError
+expectType<string>(schema.where("foo", { attr: "bar" }).models[0].attr);
+expectError(schema.where("foo", { bar: true }));
+expectType<string>(schema.where("foo", (foo) => foo.attr === "ok").models[0].attr);
+expectError(schema.where("foo", (foo) => foo.x === "ok"));
+expectError(schema.where("cow", { attr: "bar" }));
 
-schema.all("foo").models[0].attr; // $ExpectType string
-schema.all("cow"); // $ExpectError
+expectType<string>(schema.all("foo").models[0].attr);
+expectError(schema.all("cow"));
 
-schema.none("foo").models[0].attr; // $ExpectType string
-schema.none("cow"); // $ExpectError
+expectType<string>(schema.none("foo").models[0].attr);
+expectError(schema.none("cow"));
 
-schema.first("foo")?.attr; // $ExpectType string | undefined
-schema.first("cow"); // $ExpectError
+expectType<string | undefined>(schema.first("foo")?.attr);
+expectError(schema.first("cow"));

--- a/types/tests/schema-test.ts
+++ b/types/tests/schema-test.ts
@@ -1,4 +1,4 @@
-import {expectType, expectError} from 'tsd';
+import { expectType, expectError } from "tsd";
 import { Factory, Model, Registry } from "miragejs";
 import Schema from "miragejs/orm/schema";
 
@@ -30,7 +30,9 @@ expectError(schema.findOrCreateBy("cow", { attr: "bar" }));
 
 expectType<string>(schema.where("foo", { attr: "bar" }).models[0].attr);
 expectError(schema.where("foo", { bar: true }));
-expectType<string>(schema.where("foo", (foo) => foo.attr === "ok").models[0].attr);
+expectType<string>(
+  schema.where("foo", (foo) => foo.attr === "ok").models[0].attr
+);
 expectError(schema.where("foo", (foo) => foo.x === "ok"));
 expectError(schema.where("cow", { attr: "bar" }));
 

--- a/types/tests/server-test.ts
+++ b/types/tests/server-test.ts
@@ -1,4 +1,4 @@
-import {expectType, expectError} from 'tsd';
+import { expectType, expectError } from "tsd";
 
 import {
   Response,
@@ -10,7 +10,7 @@ import {
   hasMany,
   Factory,
 } from "miragejs";
-import Db from 'miragejs/db';
+import Db from "miragejs/db";
 
 export default function config(this: Server): void {
   this.namespace = "foo";
@@ -41,9 +41,13 @@ export default function config(this: Server): void {
   expectType<void>(this.resource("foo"));
 
   expectType<void>(this.passthrough("/_coverage/upload"));
-  expectType<void>(this.passthrough("/_coverage/upload_a", "/_coverage/upload_b"));
+  expectType<void>(
+    this.passthrough("/_coverage/upload_a", "/_coverage/upload_b")
+  );
   expectError(this.passthrough(["/_coverage/upload"]));
-  expectType<void>(this.passthrough((request) => request.queryParams.skipMirage));
+  expectType<void>(
+    this.passthrough((request) => request.queryParams.skipMirage)
+  );
   expectType<void>(this.passthrough("/_coverage/upload", ["get"]));
   // prettier-ignore
   expectType<void>(this.passthrough("/_coverage/upload", (request) => request.queryParams.skipMirage));
@@ -60,7 +64,9 @@ export default function config(this: Server): void {
     expectType<Db>(schema.db);
 
     expectType<Record<string, string>>(request.params);
-    expectType<Record<string, string | string[] | null | undefined>>(request.queryParams);
+    expectType<Record<string, string | string[] | null | undefined>>(
+      request.queryParams
+    );
     expectType<string>(request.requestBody);
     expectType<Record<string, string>>(request.requestHeaders);
     expectType<string>(request.url);
@@ -68,7 +74,11 @@ export default function config(this: Server): void {
     return new Response(200, { "Content-Type": "application/json" }, "{}");
   });
 
-  expectType<void>(this.get("/test/:segment", (schema) => Promise.resolve(schema.create("foo"))));
+  expectType<void>(
+    this.get("/test/:segment", (schema) =>
+      Promise.resolve(schema.create("foo"))
+    )
+  );
 }
 
 // In `new Server`, models and factories are untyped, and you can
@@ -152,8 +162,10 @@ createServer({
       return person ?? new Response(404);
     });
 
-    expectError(this.get("bad", () => {
-      return this.schema.all("typo");
-    }));
+    expectError(
+      this.get("bad", () => {
+        return this.schema.all("typo");
+      })
+    );
   },
 });

--- a/types/tests/server-test.ts
+++ b/types/tests/server-test.ts
@@ -1,4 +1,5 @@
-// Minimum TypeScript Version: 4.2
+import {expectType, expectError} from 'tsd';
+
 import {
   Response,
   Server,
@@ -9,6 +10,7 @@ import {
   hasMany,
   Factory,
 } from "miragejs";
+import Db from 'miragejs/db';
 
 export default function config(this: Server): void {
   this.namespace = "foo";
@@ -16,12 +18,12 @@ export default function config(this: Server): void {
   this.timing = 123;
   this.logging = true;
 
-  this.get("/foo"); // $ExpectType void
-  this.put("/foo"); // $ExpectType void
-  this.post("/foo"); // $ExpectType void
-  this.patch("/foo"); // $ExpectType void
-  this.options("/foo"); // $ExpectType void
-  this.del("/foo"); // $ExpectType void
+  expectType<void>(this.get("/foo"));
+  expectType<void>(this.put("/foo"));
+  expectType<void>(this.post("/foo"));
+  expectType<void>(this.patch("/foo"));
+  expectType<void>(this.options("/foo"));
+  expectType<void>(this.del("/foo"));
 
   this.get("/foo", () => ({}));
   this.get("/foo", () => 0);
@@ -33,40 +35,40 @@ export default function config(this: Server): void {
   this.get<number>("/foo", () => 0);
   this.get<[number, string]>("/foo", () => [0, "foo"]);
 
-  this.get<number>("/foo", () => false); // $ExpectError
-  this.get<[number, string]>("/foo", () => ["foo", 0]); // $ExpectError
+  expectError(this.get<number>("/foo", () => false));
+  expectError(this.get<[number, string]>("/foo", () => ["foo", 0]));
 
-  this.resource("foo"); // $ExpectType void
+  expectType<void>(this.resource("foo"));
 
-  this.passthrough("/_coverage/upload"); // $ExpectType void
-  this.passthrough("/_coverage/upload_a", "/_coverage/upload_b"); // $ExpectType void
-  this.passthrough(["/_coverage/upload"]); // $ExpectError
-  this.passthrough((request) => request.queryParams.skipMirage); // $ExpectType void
-  this.passthrough("/_coverage/upload", ["get"]); // $ExpectType void
+  expectType<void>(this.passthrough("/_coverage/upload"));
+  expectType<void>(this.passthrough("/_coverage/upload_a", "/_coverage/upload_b"));
+  expectError(this.passthrough(["/_coverage/upload"]));
+  expectType<void>(this.passthrough((request) => request.queryParams.skipMirage));
+  expectType<void>(this.passthrough("/_coverage/upload", ["get"]));
   // prettier-ignore
-  this.passthrough("/_coverage/upload", (request) => request.queryParams.skipMirage); // $ExpectType void
+  expectType<void>(this.passthrough("/_coverage/upload", (request) => request.queryParams.skipMirage));
   // prettier-ignore
-  this.passthrough("/_coverage/upload", (request) => request.queryParams.skipMirage, ["post"]); // $ExpectType void
+  expectType<void>(this.passthrough("/_coverage/upload", (request) => request.queryParams.skipMirage, ["post"]));
 
-  this.loadFixtures(); // $ExpectType void
-  this.seeds(this); // $ExpectType void
-  this.routes(); // $ExpectType void
+  expectType<void>(this.loadFixtures());
+  expectType<void>(this.seeds(this));
+  expectType<void>(this.routes());
 
-  this.shutdown(); // $ExpectType void
+  expectType<void>(this.shutdown());
 
   this.get("/test/:segment", (schema, request) => {
-    schema.db; // $ExpectType Db
+    expectType<Db>(schema.db);
 
-    request.params; // $ExpectType Record<string, string>
-    request.queryParams; // $ExpectType Record<string, string | string[] | null | undefined>
-    request.requestBody; // $ExpectType string
-    request.requestHeaders; // $ExpectType Record<string, string>
-    request.url; // $ExpectType string
+    expectType<Record<string, string>>(request.params);
+    expectType<Record<string, string | string[] | null | undefined>>(request.queryParams);
+    expectType<string>(request.requestBody);
+    expectType<Record<string, string>>(request.requestHeaders);
+    expectType<string>(request.url);
 
     return new Response(200, { "Content-Type": "application/json" }, "{}");
   });
 
-  this.get("/test/:segment", (schema) => Promise.resolve(schema.create("foo"))); // $ExpectType void
+  expectType<void>(this.get("/test/:segment", (schema) => Promise.resolve(schema.create("foo"))));
 }
 
 // In `new Server`, models and factories are untyped, and you can
@@ -136,22 +138,22 @@ createServer({
     this.get("people/:id", (schema, request) => {
       let person = this.schema.find("person", request.params.id);
 
-      person?.name; // $ExpectType string | undefined
+      expectType<string | undefined>(person?.name);
 
       let friend = person?.friends.models[0];
 
-      friend?.name; // $ExpectType string | undefined
-      friend?.children; // $ExpectError
+      expectType<string | undefined>(friend?.name);
+      expectError(friend?.children);
 
       if (friend && "friends" in friend) {
-        friend.children.modelName; // $ExpectType string
+        expectType<string>(friend.children.modelName);
       }
 
       return person ?? new Response(404);
     });
 
-    this.get("bad", () => {
-      return this.schema.all("typo"); // $ExpectError
-    });
+    expectError(this.get("bad", () => {
+      return this.schema.all("typo");
+    }));
   },
 });

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -1,14 +1,16 @@
 {
   "compilerOptions": {
-    "target": "es6",
-    "lib": ["es6", "dom"],
-    "module": "ES6",
-    "types": [],
-    "noEmit": true,
     "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "baseUrl": ".",
-    "paths": { "miragejs": ["."] },
-    "moduleResolution": "Node"
+    "noEmit": true,
+    "target": "es2020",
+    "lib": ["es2020", "dom", "dom.iterable"],
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "noUnusedLocals": false,
+    "moduleResolution": "node",
+    "skipLibCheck": false,
+    "paths": {
+      "miragejs": ["./index.d.ts"]
+    }
   }
 }

--- a/types/tslint.json
+++ b/types/tslint.json
@@ -1,3 +1,0 @@
-{
-  "extends": ["dtslint/dtslint.json", "tslint-config-prettier"]
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2076,6 +2076,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tsd/typescript@npm:~5.8.3":
+  version: 5.8.3
+  resolution: "@tsd/typescript@npm:5.8.3"
+  checksum: 10c0/d136086026f66286fb4f5b02f88109c4bcfe965956620c8eec2ee9aebe9e2d03caba208df0c0612209954de2df4ef2f9ff1c845b8d500b7db6e819585d3ade71
+  languageName: node
+  linkType: hard
+
 "@types/babel__core@npm:^7.1.14":
   version: 7.20.5
   resolution: "@types/babel__core@npm:7.20.5"
@@ -2114,6 +2121,16 @@ __metadata:
   dependencies:
     "@babel/types": "npm:^7.20.7"
   checksum: 10c0/7ba7db61a53e28cac955aa99af280d2600f15a8c056619c05b6fc911cbe02c61aa4f2823299221b23ce0cce00b294c0e5f618ec772aa3f247523c2e48cf7b888
+  languageName: node
+  linkType: hard
+
+"@types/eslint@npm:^7.2.13":
+  version: 7.29.0
+  resolution: "@types/eslint@npm:7.29.0"
+  dependencies:
+    "@types/estree": "npm:*"
+    "@types/json-schema": "npm:*"
+  checksum: 10c0/780ea3f4abba77a577a9ca5c4b66f74acc0f5ff5162b9a361ca931763ed65bca062389fc26027b416ed0a54d390e2206412db6c682f565e523d2b82159e6c46f
   languageName: node
   linkType: hard
 
@@ -2169,10 +2186,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/json-schema@npm:*":
+  version: 7.0.15
+  resolution: "@types/json-schema@npm:7.0.15"
+  checksum: 10c0/a996a745e6c5d60292f36731dd41341339d4eeed8180bb09226e5c8d23759067692b1d88e5d91d72ee83dfc00d3aca8e7bd43ea120516c17922cbcb7c3e252db
+  languageName: node
+  linkType: hard
+
 "@types/json5@npm:^0.0.29":
   version: 0.0.29
   resolution: "@types/json5@npm:0.0.29"
   checksum: 10c0/6bf5337bc447b706bb5b4431d37686aa2ea6d07cfd6f79cc31de80170d6ff9b1c7384a9c0ccbc45b3f512bae9e9f75c2e12109806a15331dc94e8a8db6dbb4ac
+  languageName: node
+  linkType: hard
+
+"@types/minimist@npm:^1.2.0":
+  version: 1.2.5
+  resolution: "@types/minimist@npm:1.2.5"
+  checksum: 10c0/3f791258d8e99a1d7d0ca2bda1ca6ea5a94e5e7b8fc6cde84dd79b0552da6fb68ade750f0e17718f6587783c24254bbca0357648dd59dc3812c150305cabdc46
   languageName: node
   linkType: hard
 
@@ -2182,6 +2213,13 @@ __metadata:
   dependencies:
     undici-types: "npm:~5.26.4"
   checksum: 10c0/2d86e5f2227aaa42212e82ea0affe72799111b888ff900916376450b02b09b963ca888b20d9c332d8d2b833ed4781987867a38eaa2e4863fa8439071468b0a6f
+  languageName: node
+  linkType: hard
+
+"@types/normalize-package-data@npm:^2.4.0":
+  version: 2.4.4
+  resolution: "@types/normalize-package-data@npm:2.4.4"
+  checksum: 10c0/aef7bb9b015883d6f4119c423dd28c4bdc17b0e8a0ccf112c78b4fe0e91fbc4af7c6204b04bba0e199a57d2f3fbbd5b4a14bf8739bf9d2a39b2a0aad545e0f86
   languageName: node
   linkType: hard
 
@@ -2555,6 +2593,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"arrify@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "arrify@npm:1.0.1"
+  checksum: 10c0/c35c8d1a81bcd5474c0c57fe3f4bad1a4d46a5fa353cedcff7a54da315df60db71829e69104b859dff96c5d68af46bd2be259fe5e50dc6aa9df3b36bea0383ab
+  languageName: node
+  linkType: hard
+
 "asynckit@npm:^0.4.0":
   version: 0.4.0
   resolution: "asynckit@npm:0.4.0"
@@ -2748,13 +2793,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"builtin-modules@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "builtin-modules@npm:1.1.1"
-  checksum: 10c0/58d72ea7f59db3c2ae854e1058d85b226f75ff7386d0f71d628e25a600383fc6652af218e20ba2361925c605a4144590ceb890dfdca298fdf8f3d040c0591a23
-  languageName: node
-  linkType: hard
-
 "builtin-modules@npm:^3.3.0":
   version: 3.3.0
   resolution: "builtin-modules@npm:3.3.0"
@@ -2802,6 +2840,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"camelcase-keys@npm:^6.2.2":
+  version: 6.2.2
+  resolution: "camelcase-keys@npm:6.2.2"
+  dependencies:
+    camelcase: "npm:^5.3.1"
+    map-obj: "npm:^4.0.0"
+    quick-lru: "npm:^4.0.1"
+  checksum: 10c0/bf1a28348c0f285c6c6f68fb98a9d088d3c0269fed0cdff3ea680d5a42df8a067b4de374e7a33e619eb9d5266a448fe66c2dd1f8e0c9209ebc348632882a3526
+  languageName: node
+  linkType: hard
+
 "camelcase@npm:^5.3.1":
   version: 5.3.1
   resolution: "camelcase@npm:5.3.1"
@@ -2823,7 +2872,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^2.3.0, chalk@npm:^2.4.1, chalk@npm:^2.4.2":
+"chalk@npm:^2.4.1, chalk@npm:^2.4.2":
   version: 2.4.2
   resolution: "chalk@npm:2.4.2"
   dependencies:
@@ -2834,7 +2883,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^4.0.0":
+"chalk@npm:^4.0.0, chalk@npm:^4.1.0":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
   dependencies:
@@ -2942,13 +2991,6 @@ __metadata:
   dependencies:
     delayed-stream: "npm:~1.0.0"
   checksum: 10c0/0dbb829577e1b1e839fa82b40c07ffaf7de8a09b935cadd355a73652ae70a88b4320db322f6634a4ad93424292fa80973ac6480986247f1734a1137debf271d5
-  languageName: node
-  linkType: hard
-
-"commander@npm:^2.12.1":
-  version: 2.20.3
-  resolution: "commander@npm:2.20.3"
-  checksum: 10c0/74c781a5248c2402a0a3e966a0a2bba3c054aad144f5c023364be83265e796b20565aa9feff624132ff629aa64e16999fa40a743c10c12f7c61e96a794b99288
   languageName: node
   linkType: hard
 
@@ -3118,6 +3160,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"decamelize-keys@npm:^1.1.0":
+  version: 1.1.1
+  resolution: "decamelize-keys@npm:1.1.1"
+  dependencies:
+    decamelize: "npm:^1.1.0"
+    map-obj: "npm:^1.0.0"
+  checksum: 10c0/4ca385933127437658338c65fb9aead5f21b28d3dd3ccd7956eb29aab0953b5d3c047fbc207111672220c71ecf7a4d34f36c92851b7bbde6fca1a02c541bdd7d
+  languageName: node
+  linkType: hard
+
+"decamelize@npm:^1.1.0, decamelize@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "decamelize@npm:1.2.0"
+  checksum: 10c0/85c39fe8fbf0482d4a1e224ef0119db5c1897f8503bcef8b826adff7a1b11414972f6fef2d7dec2ee0b4be3863cf64ac1439137ae9e6af23a3d8dcbe26a5b4b2
+  languageName: node
+  linkType: hard
+
 "decimal.js@npm:^10.4.2":
   version: 10.4.3
   resolution: "decimal.js@npm:10.4.3"
@@ -3191,13 +3250,6 @@ __metadata:
   version: 29.6.3
   resolution: "diff-sequences@npm:29.6.3"
   checksum: 10c0/32e27ac7dbffdf2fb0eb5a84efd98a9ad084fbabd5ac9abb8757c6770d5320d2acd172830b28c4add29bb873d59420601dfc805ac4064330ce59b1adfd0593b2
-  languageName: node
-  linkType: hard
-
-"diff@npm:^4.0.1":
-  version: 4.0.2
-  resolution: "diff@npm:4.0.2"
-  checksum: 10c0/81b91f9d39c4eaca068eb0c1eb0e4afbdc5bb2941d197f513dd596b820b956fef43485876226d65d497bebc15666aa2aa82c679e84f65d5f2bfbf14ee46e32c1
   languageName: node
   linkType: hard
 
@@ -3478,6 +3530,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-formatter-pretty@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "eslint-formatter-pretty@npm:4.1.0"
+  dependencies:
+    "@types/eslint": "npm:^7.2.13"
+    ansi-escapes: "npm:^4.2.1"
+    chalk: "npm:^4.1.0"
+    eslint-rule-docs: "npm:^1.1.5"
+    log-symbols: "npm:^4.0.0"
+    plur: "npm:^4.0.0"
+    string-width: "npm:^4.2.0"
+    supports-hyperlinks: "npm:^2.0.0"
+  checksum: 10c0/7cc55b873d3e9a5049cf0db65cef873abfc299639e7527bed52dea61f0742661b68e48018cf05de4c9cd8fb9362badc20f22c50fd5f36d745a346fa17bac8b60
+  languageName: node
+  linkType: hard
+
 "eslint-import-resolver-alias@npm:^1.1.2":
   version: 1.1.2
   resolution: "eslint-import-resolver-alias@npm:1.1.2"
@@ -3600,6 +3668,13 @@ __metadata:
     eslint-config-prettier:
       optional: true
   checksum: 10c0/f45d5fc1fcfec6b0cf038a7a65ddd10a25df4fe3f9e1f6b7f0d5100e66f046a26a2492e69ee765dddf461b93c114cf2e1eb18d4970aafa6f385448985c136e09
+  languageName: node
+  linkType: hard
+
+"eslint-rule-docs@npm:^1.1.5":
+  version: 1.1.235
+  resolution: "eslint-rule-docs@npm:1.1.235"
+  checksum: 10c0/76a735c1e13a511ddff1017d5913b2526643827c8fdc86a23467f680b8dcbdfd07806cb092c82dd8d0e99789f23c8a38b9d2b838cd1cd62cc1932612ed606b8e
   languageName: node
   linkType: hard
 
@@ -4119,7 +4194,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^7.1.1, glob@npm:^7.1.3, glob@npm:^7.1.4":
+"glob@npm:^7.1.3, glob@npm:^7.1.4":
   version: 7.2.3
   resolution: "glob@npm:7.2.3"
   dependencies:
@@ -4159,7 +4234,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globby@npm:^11.1.0":
+"globby@npm:^11.0.1, globby@npm:^11.1.0":
   version: 11.1.0
   resolution: "globby@npm:11.1.0"
   dependencies:
@@ -4193,6 +4268,13 @@ __metadata:
   version: 1.4.0
   resolution: "graphemer@npm:1.4.0"
   checksum: 10c0/e951259d8cd2e0d196c72ec711add7115d42eb9a8146c8eeda5b8d3ac91e5dd816b9cd68920726d9fd4490368e7ed86e9c423f40db87e2d8dfafa00fa17c3a31
+  languageName: node
+  linkType: hard
+
+"hard-rejection@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "hard-rejection@npm:2.1.0"
+  checksum: 10c0/febc3343a1ad575aedcc112580835b44a89a89e01f400b4eda6e8110869edfdab0b00cd1bd4c3bfec9475a57e79e0b355aecd5be46454b6a62b9a359af60e564
   languageName: node
   linkType: hard
 
@@ -4262,6 +4344,15 @@ __metadata:
   version: 2.8.9
   resolution: "hosted-git-info@npm:2.8.9"
   checksum: 10c0/317cbc6b1bbbe23c2a40ae23f3dafe9fa349ce42a89a36f930e3f9c0530c179a3882d2ef1e4141a4c3674d6faaea862138ec55b43ad6f75e387fda2483a13c70
+  languageName: node
+  linkType: hard
+
+"hosted-git-info@npm:^4.0.1":
+  version: 4.1.0
+  resolution: "hosted-git-info@npm:4.1.0"
+  dependencies:
+    lru-cache: "npm:^6.0.0"
+  checksum: 10c0/150fbcb001600336d17fdbae803264abed013548eea7946c2264c49ebe2ebd8c4441ba71dd23dd8e18c65de79d637f98b22d4760ba5fb2e0b15d62543d0fff07
   languageName: node
   linkType: hard
 
@@ -4433,6 +4524,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"irregular-plurals@npm:^3.2.0":
+  version: 3.5.0
+  resolution: "irregular-plurals@npm:3.5.0"
+  checksum: 10c0/7c033bbe7325e5a6e0a26949cc6863b6ce273403d4cd5b93bd99b33fecb6605b0884097c4259c23ed0c52c2133bf7d1cdcdd7a0630e8c325161fe269b3447918
+  languageName: node
+  linkType: hard
+
 "is-array-buffer@npm:^3.0.4":
   version: 3.0.4
   resolution: "is-array-buffer@npm:3.0.4"
@@ -4491,6 +4589,15 @@ __metadata:
   dependencies:
     hasown: "npm:^2.0.0"
   checksum: 10c0/2cba9903aaa52718f11c4896dabc189bab980870aae86a62dc0d5cedb546896770ee946fb14c84b7adf0735f5eaea4277243f1b95f5cefa90054f92fbcac2518
+  languageName: node
+  linkType: hard
+
+"is-core-module@npm:^2.5.0":
+  version: 2.16.1
+  resolution: "is-core-module@npm:2.16.1"
+  dependencies:
+    hasown: "npm:^2.0.2"
+  checksum: 10c0/898443c14780a577e807618aaae2b6f745c8538eca5c7bc11388a3f2dc6de82b9902bcc7eb74f07be672b11bbe82dd6a6edded44a00cb3d8f933d0459905eedd
   languageName: node
   linkType: hard
 
@@ -4586,6 +4693,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-plain-obj@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "is-plain-obj@npm:1.1.0"
+  checksum: 10c0/daaee1805add26f781b413fdf192fc91d52409583be30ace35c82607d440da63cc4cac0ac55136716688d6c0a2c6ef3edb2254fecbd1fe06056d6bd15975ee8c
+  languageName: node
+  linkType: hard
+
 "is-potential-custom-element-name@npm:^1.0.1":
   version: 1.0.1
   resolution: "is-potential-custom-element-name@npm:1.0.1"
@@ -4652,6 +4766,13 @@ __metadata:
   dependencies:
     which-typed-array: "npm:^1.1.14"
   checksum: 10c0/fa5cb97d4a80e52c2cc8ed3778e39f175a1a2ae4ddf3adae3187d69586a1fd57cfa0b095db31f66aa90331e9e3da79184cea9c6abdcd1abc722dc3c3edd51cca
+  languageName: node
+  linkType: hard
+
+"is-unicode-supported@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "is-unicode-supported@npm:0.1.0"
+  checksum: 10c0/00cbe3455c3756be68d2542c416cab888aebd5012781d6819749fefb15162ff23e38501fe681b3d751c73e8ff561ac09a5293eba6f58fdf0178462ce6dcb3453
   languageName: node
   linkType: hard
 
@@ -4866,7 +4987,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-diff@npm:^29.0.0, jest-diff@npm:^29.7.0":
+"jest-diff@npm:^29.0.0, jest-diff@npm:^29.0.3, jest-diff@npm:^29.7.0":
   version: 29.7.0
   resolution: "jest-diff@npm:29.7.0"
   dependencies:
@@ -5405,6 +5526,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"kind-of@npm:^6.0.3":
+  version: 6.0.3
+  resolution: "kind-of@npm:6.0.3"
+  checksum: 10c0/61cdff9623dabf3568b6445e93e31376bee1cdb93f8ba7033d86022c2a9b1791a1d9510e026e6465ebd701a6dd2f7b0808483ad8838341ac52f003f512e0b4c4
+  languageName: node
+  linkType: hard
+
 "kleur@npm:^3.0.3":
   version: 3.0.3
   resolution: "kleur@npm:3.0.3"
@@ -5487,6 +5615,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"log-symbols@npm:^4.0.0":
+  version: 4.1.0
+  resolution: "log-symbols@npm:4.1.0"
+  dependencies:
+    chalk: "npm:^4.1.0"
+    is-unicode-supported: "npm:^0.1.0"
+  checksum: 10c0/67f445a9ffa76db1989d0fa98586e5bc2fd5247260dafb8ad93d9f0ccd5896d53fb830b0e54dade5ad838b9de2006c826831a3c528913093af20dff8bd24aca6
+  languageName: node
+  linkType: hard
+
 "lru-cache@npm:^10.0.1, lru-cache@npm:^10.2.0":
   version: 10.2.2
   resolution: "lru-cache@npm:10.2.2"
@@ -5500,6 +5638,15 @@ __metadata:
   dependencies:
     yallist: "npm:^3.0.2"
   checksum: 10c0/89b2ef2ef45f543011e38737b8a8622a2f8998cddf0e5437174ef8f1f70a8b9d14a918ab3e232cb3ba343b7abddffa667f0b59075b2b80e6b4d63c3de6127482
+  languageName: node
+  linkType: hard
+
+"lru-cache@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "lru-cache@npm:6.0.0"
+  dependencies:
+    yallist: "npm:^4.0.0"
+  checksum: 10c0/cb53e582785c48187d7a188d3379c181b5ca2a9c78d2bce3e7dee36f32761d1c42983da3fe12b55cb74e1779fa94cdc2e5367c028a9b35317184ede0c07a30a9
   languageName: node
   linkType: hard
 
@@ -5550,10 +5697,44 @@ __metadata:
   languageName: node
   linkType: hard
 
+"map-obj@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "map-obj@npm:1.0.1"
+  checksum: 10c0/ccca88395e7d38671ed9f5652ecf471ecd546924be2fb900836b9da35e068a96687d96a5f93dcdfa94d9a27d649d2f10a84595590f89a347fb4dda47629dcc52
+  languageName: node
+  linkType: hard
+
+"map-obj@npm:^4.0.0":
+  version: 4.3.0
+  resolution: "map-obj@npm:4.3.0"
+  checksum: 10c0/1c19e1c88513c8abdab25c316367154c6a0a6a0f77e3e8c391bb7c0e093aefed293f539d026dc013d86219e5e4c25f23b0003ea588be2101ccd757bacc12d43b
+  languageName: node
+  linkType: hard
+
 "memorystream@npm:^0.3.1":
   version: 0.3.1
   resolution: "memorystream@npm:0.3.1"
   checksum: 10c0/4bd164657711d9747ff5edb0508b2944414da3464b7fe21ac5c67cf35bba975c4b446a0124bd0f9a8be54cfc18faf92e92bd77563a20328b1ccf2ff04e9f39b9
+  languageName: node
+  linkType: hard
+
+"meow@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "meow@npm:9.0.0"
+  dependencies:
+    "@types/minimist": "npm:^1.2.0"
+    camelcase-keys: "npm:^6.2.2"
+    decamelize: "npm:^1.2.0"
+    decamelize-keys: "npm:^1.1.0"
+    hard-rejection: "npm:^2.1.0"
+    minimist-options: "npm:4.1.0"
+    normalize-package-data: "npm:^3.0.0"
+    read-pkg-up: "npm:^7.0.1"
+    redent: "npm:^3.0.0"
+    trim-newlines: "npm:^3.0.0"
+    type-fest: "npm:^0.18.0"
+    yargs-parser: "npm:^20.2.3"
+  checksum: 10c0/998955ecff999dc3f3867ef3b51999218212497f27d75b9cbe10bdb73aac4ee308d484f7801fd1b3cfa4172819065f65f076ca018c1412fab19d0ea486648722
   languageName: node
   linkType: hard
 
@@ -5604,6 +5785,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"min-indent@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "min-indent@npm:1.0.1"
+  checksum: 10c0/7e207bd5c20401b292de291f02913230cb1163abca162044f7db1d951fa245b174dc00869d40dd9a9f32a885ad6a5f3e767ee104cf278f399cb4e92d3f582d5c
+  languageName: node
+  linkType: hard
+
 "minimatch@npm:^3.0.4, minimatch@npm:^3.0.5, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
   version: 3.1.2
   resolution: "minimatch@npm:3.1.2"
@@ -5619,6 +5807,17 @@ __metadata:
   dependencies:
     brace-expansion: "npm:^2.0.1"
   checksum: 10c0/2c16f21f50e64922864e560ff97c587d15fd491f65d92a677a344e970fe62aafdbeafe648965fa96d33c061b4d0eabfe0213466203dd793367e7f28658cf6414
+  languageName: node
+  linkType: hard
+
+"minimist-options@npm:4.1.0":
+  version: 4.1.0
+  resolution: "minimist-options@npm:4.1.0"
+  dependencies:
+    arrify: "npm:^1.0.1"
+    is-plain-obj: "npm:^1.1.0"
+    kind-of: "npm:^6.0.3"
+  checksum: 10c0/7871f9cdd15d1e7374e5b013e2ceda3d327a06a8c7b38ae16d9ef941e07d985e952c589e57213f7aa90a8744c60aed9524c0d85e501f5478382d9181f2763f54
   languageName: node
   linkType: hard
 
@@ -5746,22 +5945,10 @@ __metadata:
     prettier: "npm:3.3.2"
     rimraf: "npm:^5.0.7"
     rollup: "npm:^4.18.0"
-    tslint: "npm:^6.1.3"
-    tslint-config-prettier: "npm:^1.18.0"
+    tsd: "npm:^0.32.0"
     typescript: "npm:^5.4.5"
   languageName: unknown
   linkType: soft
-
-"mkdirp@npm:^0.5.3":
-  version: 0.5.6
-  resolution: "mkdirp@npm:0.5.6"
-  dependencies:
-    minimist: "npm:^1.2.6"
-  bin:
-    mkdirp: bin/cmd.js
-  checksum: 10c0/e2e2be789218807b58abced04e7b49851d9e46e88a2f9539242cc8a92c9b5c3a0b9bab360bd3014e02a140fc4fbc58e31176c408b493f8a2a6f4986bd7527b01
-  languageName: node
-  linkType: hard
 
 "mkdirp@npm:^1.0.3":
   version: 1.0.4
@@ -5852,7 +6039,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"normalize-package-data@npm:^2.3.2":
+"normalize-package-data@npm:^2.3.2, normalize-package-data@npm:^2.5.0":
   version: 2.5.0
   resolution: "normalize-package-data@npm:2.5.0"
   dependencies:
@@ -5861,6 +6048,18 @@ __metadata:
     semver: "npm:2 || 3 || 4 || 5"
     validate-npm-package-license: "npm:^3.0.1"
   checksum: 10c0/357cb1646deb42f8eb4c7d42c4edf0eec312f3628c2ef98501963cc4bbe7277021b2b1d977f982b2edce78f5a1014613ce9cf38085c3df2d76730481357ca504
+  languageName: node
+  linkType: hard
+
+"normalize-package-data@npm:^3.0.0":
+  version: 3.0.3
+  resolution: "normalize-package-data@npm:3.0.3"
+  dependencies:
+    hosted-git-info: "npm:^4.0.1"
+    is-core-module: "npm:^2.5.0"
+    semver: "npm:^7.3.4"
+    validate-npm-package-license: "npm:^3.0.1"
+  checksum: 10c0/e5d0f739ba2c465d41f77c9d950e291ea4af78f8816ddb91c5da62257c40b76d8c83278b0d08ffbcd0f187636ebddad20e181e924873916d03e6e5ea2ef026be
   languageName: node
   linkType: hard
 
@@ -6071,7 +6270,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"parse-json@npm:^5.2.0":
+"parse-json@npm:^5.0.0, parse-json@npm:^5.2.0":
   version: 5.2.0
   resolution: "parse-json@npm:5.2.0"
   dependencies:
@@ -6199,6 +6398,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"plur@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "plur@npm:4.0.0"
+  dependencies:
+    irregular-plurals: "npm:^3.2.0"
+  checksum: 10c0/4d3010843dac60b980c9b83d4cdecc2c6bb4bf0a1d7620ba7229b5badcbc3c3767fddfdb61746f6253c3bd33ada3523375983cbe0b3f94868f4a475b9b6bd7d7
+  languageName: node
+  linkType: hard
+
 "possible-typed-array-names@npm:^1.0.0":
   version: 1.0.0
   resolution: "possible-typed-array-names@npm:1.0.0"
@@ -6321,10 +6529,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"quick-lru@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "quick-lru@npm:4.0.1"
+  checksum: 10c0/f9b1596fa7595a35c2f9d913ac312fede13d37dc8a747a51557ab36e11ce113bbe88ef4c0154968845559a7709cb6a7e7cbe75f7972182451cd45e7f057a334d
+  languageName: node
+  linkType: hard
+
 "react-is@npm:^18.0.0":
   version: 18.3.1
   resolution: "react-is@npm:18.3.1"
   checksum: 10c0/f2f1e60010c683479e74c63f96b09fb41603527cd131a9959e2aee1e5a8b0caf270b365e5ca77d4a6b18aae659b60a86150bb3979073528877029b35aecd2072
+  languageName: node
+  linkType: hard
+
+"read-pkg-up@npm:^7.0.0, read-pkg-up@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "read-pkg-up@npm:7.0.1"
+  dependencies:
+    find-up: "npm:^4.1.0"
+    read-pkg: "npm:^5.2.0"
+    type-fest: "npm:^0.8.1"
+  checksum: 10c0/82b3ac9fd7c6ca1bdc1d7253eb1091a98ff3d195ee0a45386582ce3e69f90266163c34121e6a0a02f1630073a6c0585f7880b3865efcae9c452fa667f02ca385
   languageName: node
   linkType: hard
 
@@ -6336,6 +6562,28 @@ __metadata:
     normalize-package-data: "npm:^2.3.2"
     path-type: "npm:^3.0.0"
   checksum: 10c0/65acf2df89fbcd506b48b7ced56a255ba00adf7ecaa2db759c86cc58212f6fd80f1f0b7a85c848551a5d0685232e9b64f45c1fd5b48d85df2761a160767eeb93
+  languageName: node
+  linkType: hard
+
+"read-pkg@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "read-pkg@npm:5.2.0"
+  dependencies:
+    "@types/normalize-package-data": "npm:^2.4.0"
+    normalize-package-data: "npm:^2.5.0"
+    parse-json: "npm:^5.0.0"
+    type-fest: "npm:^0.6.0"
+  checksum: 10c0/b51a17d4b51418e777029e3a7694c9bd6c578a5ab99db544764a0b0f2c7c0f58f8a6bc101f86a6fceb8ba6d237d67c89acf6170f6b98695d0420ddc86cf109fb
+  languageName: node
+  linkType: hard
+
+"redent@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "redent@npm:3.0.0"
+  dependencies:
+    indent-string: "npm:^4.0.0"
+    strip-indent: "npm:^3.0.0"
+  checksum: 10c0/d64a6b5c0b50eb3ddce3ab770f866658a2b9998c678f797919ceb1b586bab9259b311407280bd80b804e2a7c7539b19238ae6a2a20c843f1a7fcff21d48c2eae
   languageName: node
   linkType: hard
 
@@ -6459,7 +6707,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@npm:^1.10.0, resolve@npm:^1.10.1, resolve@npm:^1.14.2, resolve@npm:^1.20.0, resolve@npm:^1.22.1, resolve@npm:^1.22.4, resolve@npm:^1.3.2":
+"resolve@npm:^1.10.0, resolve@npm:^1.10.1, resolve@npm:^1.14.2, resolve@npm:^1.20.0, resolve@npm:^1.22.1, resolve@npm:^1.22.4":
   version: 1.22.8
   resolution: "resolve@npm:1.22.8"
   dependencies:
@@ -6472,7 +6720,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@npm%3A^1.10.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.10.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.14.2#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.4#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.3.2#optional!builtin<compat/resolve>":
+"resolve@patch:resolve@npm%3A^1.10.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.10.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.14.2#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.4#optional!builtin<compat/resolve>":
   version: 1.22.8
   resolution: "resolve@patch:resolve@npm%3A1.22.8#optional!builtin<compat/resolve>::version=1.22.8&hash=c3c19d"
   dependencies:
@@ -6639,7 +6887,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:2 || 3 || 4 || 5, semver@npm:^5.3.0, semver@npm:^5.5.0":
+"semver@npm:2 || 3 || 4 || 5, semver@npm:^5.5.0":
   version: 5.7.2
   resolution: "semver@npm:5.7.2"
   bin:
@@ -6654,6 +6902,15 @@ __metadata:
   bin:
     semver: bin/semver.js
   checksum: 10c0/e3d79b609071caa78bcb6ce2ad81c7966a46a7431d9d58b8800cfa9cb6a63699b3899a0e4bcce36167a284578212d9ae6942b6929ba4aa5015c079a67751d42d
+  languageName: node
+  linkType: hard
+
+"semver@npm:^7.3.4":
+  version: 7.7.1
+  resolution: "semver@npm:7.7.1"
+  bin:
+    semver: bin/semver.js
+  checksum: 10c0/fd603a6fb9c399c6054015433051bdbe7b99a940a8fb44b85c2b524c4004b023d7928d47cb22154f8d054ea7ee8597f586605e05b52047f048278e4ac56ae958
   languageName: node
   linkType: hard
 
@@ -7006,6 +7263,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"strip-indent@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "strip-indent@npm:3.0.0"
+  dependencies:
+    min-indent: "npm:^1.0.0"
+  checksum: 10c0/ae0deaf41c8d1001c5d4fbe16cb553865c1863da4fae036683b474fa926af9fc121e155cb3fc57a68262b2ae7d5b8420aa752c97a6428c315d00efe2a3875679
+  languageName: node
+  linkType: hard
+
 "strip-json-comments@npm:^3.1.1":
   version: 3.1.1
   resolution: "strip-json-comments@npm:3.1.1"
@@ -7022,7 +7288,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"supports-color@npm:^7.1.0":
+"supports-color@npm:^7.0.0, supports-color@npm:^7.1.0":
   version: 7.2.0
   resolution: "supports-color@npm:7.2.0"
   dependencies:
@@ -7037,6 +7303,16 @@ __metadata:
   dependencies:
     has-flag: "npm:^4.0.0"
   checksum: 10c0/ea1d3c275dd604c974670f63943ed9bd83623edc102430c05adb8efc56ba492746b6e95386e7831b872ec3807fd89dd8eb43f735195f37b5ec343e4234cc7e89
+  languageName: node
+  linkType: hard
+
+"supports-hyperlinks@npm:^2.0.0":
+  version: 2.3.0
+  resolution: "supports-hyperlinks@npm:2.3.0"
+  dependencies:
+    has-flag: "npm:^4.0.0"
+    supports-color: "npm:^7.0.0"
+  checksum: 10c0/4057f0d86afb056cd799602f72d575b8fdd79001c5894bcb691176f14e870a687e7981e50bc1484980e8b688c6d5bcd4931e1609816abb5a7dc1486b7babf6a1
   languageName: node
   linkType: hard
 
@@ -7140,6 +7416,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"trim-newlines@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "trim-newlines@npm:3.0.1"
+  checksum: 10c0/03cfefde6c59ff57138412b8c6be922ecc5aec30694d784f2a65ef8dcbd47faef580b7de0c949345abdc56ec4b4abf64dd1e5aea619b200316e471a3dd5bf1f6
+  languageName: node
+  linkType: hard
+
 "ts-api-utils@npm:^1.3.0":
   version: 1.3.0
   resolution: "ts-api-utils@npm:1.3.0"
@@ -7161,10 +7444,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^1.13.0, tslib@npm:^1.8.1":
-  version: 1.14.1
-  resolution: "tslib@npm:1.14.1"
-  checksum: 10c0/69ae09c49eea644bc5ebe1bca4fa4cc2c82b7b3e02f43b84bd891504edf66dbc6b2ec0eef31a957042de2269139e4acff911e6d186a258fb14069cd7f6febce2
+"tsd@npm:^0.32.0":
+  version: 0.32.0
+  resolution: "tsd@npm:0.32.0"
+  dependencies:
+    "@tsd/typescript": "npm:~5.8.3"
+    eslint-formatter-pretty: "npm:^4.1.0"
+    globby: "npm:^11.0.1"
+    jest-diff: "npm:^29.0.3"
+    meow: "npm:^9.0.0"
+    path-exists: "npm:^4.0.0"
+    read-pkg-up: "npm:^7.0.0"
+  bin:
+    tsd: dist/cli.js
+  checksum: 10c0/371e8269052f9665b7290e2049ddcc36c67320028715632b0e3e4666e6dfa8a935c801fbdcaa94393ffb7e439c4cdcb6142859560d21d2a938f5c240e7f10833
   languageName: node
   linkType: hard
 
@@ -7172,51 +7465,6 @@ __metadata:
   version: 2.6.3
   resolution: "tslib@npm:2.6.3"
   checksum: 10c0/2598aef53d9dbe711af75522464b2104724d6467b26a60f2bdac8297d2b5f1f6b86a71f61717384aa8fd897240467aaa7bcc36a0700a0faf751293d1331db39a
-  languageName: node
-  linkType: hard
-
-"tslint-config-prettier@npm:^1.18.0":
-  version: 1.18.0
-  resolution: "tslint-config-prettier@npm:1.18.0"
-  bin:
-    tslint-config-prettier-check: bin/check.js
-  checksum: 10c0/64a5e5fa921626c2be5d4e41df5940c478cb844b300edfe8990102e25e2b262491fb3f3841c48a3e465589c5317f3a5cb61889ff175102216662f0d627c9ad07
-  languageName: node
-  linkType: hard
-
-"tslint@npm:^6.1.3":
-  version: 6.1.3
-  resolution: "tslint@npm:6.1.3"
-  dependencies:
-    "@babel/code-frame": "npm:^7.0.0"
-    builtin-modules: "npm:^1.1.1"
-    chalk: "npm:^2.3.0"
-    commander: "npm:^2.12.1"
-    diff: "npm:^4.0.1"
-    glob: "npm:^7.1.1"
-    js-yaml: "npm:^3.13.1"
-    minimatch: "npm:^3.0.4"
-    mkdirp: "npm:^0.5.3"
-    resolve: "npm:^1.3.2"
-    semver: "npm:^5.3.0"
-    tslib: "npm:^1.13.0"
-    tsutils: "npm:^2.29.0"
-  peerDependencies:
-    typescript: ">=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev || >= 4.0.0-dev"
-  bin:
-    tslint: bin/tslint
-  checksum: 10c0/04717de06d187ee46ffa99e28af80f1b5a2edbec051e32b43ca681da625a61e94e5eb9ebb638fafe07975fb3536760ffd772f76c57134db723a9ecff6aeac380
-  languageName: node
-  linkType: hard
-
-"tsutils@npm:^2.29.0":
-  version: 2.29.0
-  resolution: "tsutils@npm:2.29.0"
-  dependencies:
-    tslib: "npm:^1.8.1"
-  peerDependencies:
-    typescript: ">=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev"
-  checksum: 10c0/e37794513526dbf1cf960414d0a65b956ad319dbc93171bccfe08e3fece1eea35b4e130153f41d917a0f28ecac04f3ca78e9a99c4bddc64a5f225925abc0cf14
   languageName: node
   linkType: hard
 
@@ -7236,6 +7484,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"type-fest@npm:^0.18.0":
+  version: 0.18.1
+  resolution: "type-fest@npm:0.18.1"
+  checksum: 10c0/303f5ecf40d03e1d5b635ce7660de3b33c18ed8ebc65d64920c02974d9e684c72483c23f9084587e9dd6466a2ece1da42ddc95b412a461794dd30baca95e2bac
+  languageName: node
+  linkType: hard
+
 "type-fest@npm:^0.20.2":
   version: 0.20.2
   resolution: "type-fest@npm:0.20.2"
@@ -7247,6 +7502,20 @@ __metadata:
   version: 0.21.3
   resolution: "type-fest@npm:0.21.3"
   checksum: 10c0/902bd57bfa30d51d4779b641c2bc403cdf1371fb9c91d3c058b0133694fcfdb817aef07a47f40faf79039eecbaa39ee9d3c532deff244f3a19ce68cea71a61e8
+  languageName: node
+  linkType: hard
+
+"type-fest@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "type-fest@npm:0.6.0"
+  checksum: 10c0/0c585c26416fce9ecb5691873a1301b5aff54673c7999b6f925691ed01f5b9232db408cdbb0bd003d19f5ae284322523f44092d1f81ca0a48f11f7cf0be8cd38
+  languageName: node
+  linkType: hard
+
+"type-fest@npm:^0.8.1":
+  version: 0.8.1
+  resolution: "type-fest@npm:0.8.1"
+  checksum: 10c0/dffbb99329da2aa840f506d376c863bd55f5636f4741ad6e65e82f5ce47e6914108f44f340a0b74009b0cb5d09d6752ae83203e53e98b1192cf80ecee5651636
   languageName: node
   linkType: hard
 
@@ -7654,6 +7923,13 @@ __metadata:
   version: 4.0.0
   resolution: "yallist@npm:4.0.0"
   checksum: 10c0/2286b5e8dbfe22204ab66e2ef5cc9bbb1e55dfc873bbe0d568aa943eb255d131890dfd5bf243637273d31119b870f49c18fcde2c6ffbb7a7a092b870dc90625a
+  languageName: node
+  linkType: hard
+
+"yargs-parser@npm:^20.2.3":
+  version: 20.2.9
+  resolution: "yargs-parser@npm:20.2.9"
+  checksum: 10c0/0685a8e58bbfb57fab6aefe03c6da904a59769bd803a722bb098bd5b0f29d274a1357762c7258fb487512811b8063fb5d2824a3415a0a4540598335b3b086c72
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
See #1122 

In this PR I tried to do the following:
1. Migrate typings tests from dtslint to [tsd](https://github.com/tsdjs/tsd) tool (it seems more universal compared to dtslint which works good only in DefinitelyTyped infrastructure)
2. Add type tests to CI pipeline (embed them to `yarn test`)
3. Remove type tests files from distribution (typo in .npmignore file)